### PR TITLE
feat add resume relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# resume-sdk
+# hire-sdk
 
 ## Installation
 
 ```bash
-go get github.com/A-pen-app/resume-sdk
+go get github.com/A-pen-app/hire-sdk
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/A-pen-app/resume-sdk
+module github.com/A-pen-app/hire-sdk
 
 go 1.22.8
 

--- a/models/resume.go
+++ b/models/resume.go
@@ -9,20 +9,20 @@ import (
 
 type ResumeContent struct {
 	// common
-	RealName           string              `json:"real_name"`
-	Email              string              `json:"email"`
-	PhoneNumber        string              `json:"phone_number"`
+	RealName           *string             `json:"real_name"`
+	Email              *string             `json:"email"`
+	PhoneNumber        *string             `json:"phone_number"`
 	PreferredLocations []string            `json:"preferred_locations"`
 	ExpectedSalary     *string             `json:"expected_salary"`
-	CollaborationType  []CollaborationType `json:"collaboration_type"`
+	CollaborationTypes []CollaborationType `json:"collaboration_types"`
 	AvailableStartDate *string             `json:"available_start_date"`
 	SpecialRequirement *string             `json:"special_requirement"`
-	ContactTime        []ContactTime       `json:"contact_time"`
+	ContactTimes       []ContactTime       `json:"contact_times"`
 
 	// for doctor
 	Position        *string  `json:"position,omitempty"`
 	Departments     []string `json:"departments,omitempty"`
-	CustomSpecialty *string  `json:"CustomSpecialty,omitempty"`
+	CustomSpecialty *string  `json:"custom_specialty,omitempty"`
 	Expertise       *string  `json:"expertise,omitempty"`
 
 	// for doctor and pharmacist
@@ -58,14 +58,16 @@ type AlmaMater struct {
 type CollaborationType int
 
 const (
-	CollaborationType_FullTime       CollaborationType = iota // 全職
-	CollaborationType_PartTime                                // 兼職
-	CollaborationType_Attending                               // 掛牌
-	CollaborationType_Lecturer                                // 講座
-	CollaborationType_Prescription                            // 葉配
-	CollaborationType_Endorsement                             // 代言
-	CollaborationType_Telemedicine                            // 遠距醫療
-	CollaborationType_MarketResearch                          // 市調訪談
+	CollaborationType_FullTime          CollaborationType = iota // 全職
+	CollaborationType_PartTime                                   // 兼職
+	CollaborationType_Attending                                  // 掛牌
+	CollaborationType_Lecturer                                   // 講座
+	CollaborationType_Prescription                               // 葉配
+	CollaborationType_Endorsement                                // 代言
+	CollaborationType_Telemedicine                               // 遠距醫療
+	CollaborationType_MarketResearch                             // 市調訪談
+	CollaborationType_AcademicEditing                            // 學術編輯
+	CollaborationType_ProductExperience                          // 產品體驗
 )
 
 type Resume struct {
@@ -81,7 +83,15 @@ type ResumeSnapshot struct {
 	ResumeID  string         `json:"-" db:"resume_id"`
 	Content   *ResumeContent `json:"content" db:"content"`
 	CreatedAt time.Time      `json:"-" db:"created_at"`
-	ChatID    string         `json:"chat_id" db:"chat_id"`
+}
+
+type ResumeRelation struct {
+	ID         string    `json:"-" db:"id"`
+	UserID     string    `json:"-" db:"user_id"`
+	SnapshotID string    `json:"-" db:"snapshot_id"`
+	PostID     string    `json:"-" db:"post_id"`
+	ChatID     string    `json:"-" db:"chat_id"`
+	CreatedAt  time.Time `json:"-" db:"created_at"`
 }
 
 // Value implements the driver.Valuer interface for inserting as jsonb

--- a/models/resume.go
+++ b/models/resume.go
@@ -92,6 +92,7 @@ type ResumeRelation struct {
 	PostID     string    `json:"-" db:"post_id"`
 	ChatID     string    `json:"-" db:"chat_id"`
 	CreatedAt  time.Time `json:"-" db:"created_at"`
+	UpdatedAt  time.Time `json:"-" db:"updated_at"`
 }
 
 // Value implements the driver.Valuer interface for inserting as jsonb

--- a/service/resume.go
+++ b/service/resume.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/A-pen-app/resume-sdk/models"
-	"github.com/A-pen-app/resume-sdk/store"
+	"github.com/A-pen-app/hire-sdk/models"
+	"github.com/A-pen-app/hire-sdk/store"
 )
 
 type resumeService struct {

--- a/service/service.go
+++ b/service/service.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 
-	"github.com/A-pen-app/resume-sdk/models"
+	"github.com/A-pen-app/hire-sdk/models"
 )
 
 type Resume interface {

--- a/store/resume.go
+++ b/store/resume.go
@@ -185,7 +185,8 @@ func (s *resumeStore) CreateRelation(ctx context.Context, userID string, snapsho
 		snapshot_id,
 		post_id,
 		chat_id,
-		created_at
+		created_at,
+		updated_at
 	)
 	VALUES (
 		?,
@@ -209,6 +210,7 @@ func (s *resumeStore) CreateRelation(ctx context.Context, userID string, snapsho
 		PostID:     postID,
 		ChatID:     chatID,
 		CreatedAt:  now,
+		UpdatedAt:  now,
 	}, nil
 }
 
@@ -220,7 +222,8 @@ func (s *resumeStore) GetRelation(ctx context.Context, chatID string) (*models.R
 		snapshot_id,
 		post_id,
 		chat_id,
-		created_at
+		created_at,
+		updated_at
 	FROM public.resume_relation
 	WHERE chat_id = ?
 	`
@@ -234,6 +237,7 @@ func (s *resumeStore) GetRelation(ctx context.Context, chatID string) (*models.R
 		&relation.PostID,
 		&relation.ChatID,
 		&relation.CreatedAt,
+		&relation.UpdatedAt,
 	)
 	if err != nil {
 		return nil, err

--- a/store/resume.go
+++ b/store/resume.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/A-pen-app/resume-sdk/models"
+	"github.com/A-pen-app/hire-sdk/models"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
@@ -104,7 +104,7 @@ func (s *resumeStore) Update(ctx context.Context, userID string, content *models
 	return nil
 }
 
-func (s *resumeStore) CreateSnapshot(ctx context.Context, userID string, chatID string) (*models.ResumeSnapshot, error) {
+func (s *resumeStore) CreateSnapshot(ctx context.Context, userID string) (*models.ResumeSnapshot, error) {
 	snapshotID := uuid.New().String()
 	now := time.Now()
 
@@ -118,8 +118,7 @@ func (s *resumeStore) CreateSnapshot(ctx context.Context, userID string, chatID 
 		id,
 		resume_id,
 		content,
-		created_at,
-		chat_id
+		created_at
 	)
 	VALUES (
 		?,
@@ -136,7 +135,6 @@ func (s *resumeStore) CreateSnapshot(ctx context.Context, userID string, chatID 
 		resume.ID,
 		resume.Content,
 		now,
-		chatID,
 	)
 	if err != nil {
 		return nil, err
@@ -147,7 +145,6 @@ func (s *resumeStore) CreateSnapshot(ctx context.Context, userID string, chatID 
 		ResumeID:  resume.ID,
 		Content:   resume.Content,
 		CreatedAt: now,
-		ChatID:    chatID,
 	}, nil
 }
 
@@ -157,8 +154,7 @@ func (s *resumeStore) GetSnapshot(ctx context.Context, snapshotID string) (*mode
 		id,
 		resume_id,
 		content,
-		created_at,
-		chat_id
+		created_at
 	FROM public.resume_snapshot 
 	WHERE id = ?
 	`
@@ -170,11 +166,78 @@ func (s *resumeStore) GetSnapshot(ctx context.Context, snapshotID string) (*mode
 		&snapshot.ResumeID,
 		&snapshot.Content,
 		&snapshot.CreatedAt,
-		&snapshot.ChatID,
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	return &snapshot, nil
+}
+
+func (s *resumeStore) CreateRelation(ctx context.Context, userID string, snapshotID string, chatID string, postID string) (*models.ResumeRelation, error) {
+	relationID := uuid.New().String()
+	now := time.Now()
+
+	query := `
+	INSERT INTO public.resume_relation (
+		id,
+		user_id,
+		snapshot_id,
+		post_id,
+		chat_id,
+		created_at
+	)
+	VALUES (
+		?,
+		?,
+		?,
+		?,
+		?
+	)
+	`
+	query = s.db.Rebind(query)
+
+	_, err := s.db.Exec(query, relationID, snapshotID, chatID, postID, userID, now)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.ResumeRelation{
+		ID:         relationID,
+		UserID:     userID,
+		SnapshotID: snapshotID,
+		PostID:     postID,
+		ChatID:     chatID,
+		CreatedAt:  now,
+	}, nil
+}
+
+func (s *resumeStore) GetRelation(ctx context.Context, chatID string) (*models.ResumeRelation, error) {
+	query := `
+	SELECT 
+		id,
+		user_id,
+		snapshot_id,
+		post_id,
+		chat_id,
+		created_at
+	FROM public.resume_relation
+	WHERE chat_id = ?
+	`
+	query = s.db.Rebind(query)
+
+	var relation models.ResumeRelation
+	err := s.db.QueryRowx(query, chatID).Scan(
+		&relation.ID,
+		&relation.UserID,
+		&relation.SnapshotID,
+		&relation.PostID,
+		&relation.ChatID,
+		&relation.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &relation, nil
 }

--- a/store/resume.go
+++ b/store/resume.go
@@ -193,12 +193,14 @@ func (s *resumeStore) CreateRelation(ctx context.Context, userID string, snapsho
 		?,
 		?,
 		?,
+		?,
+		?,
 		?
 	)
 	`
 	query = s.db.Rebind(query)
 
-	_, err := s.db.Exec(query, relationID, snapshotID, chatID, postID, userID, now)
+	_, err := s.db.Exec(query, relationID, userID, snapshotID, postID, chatID, now, now)
 	if err != nil {
 		return nil, err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -3,13 +3,15 @@ package store
 import (
 	"context"
 
-	"github.com/A-pen-app/resume-sdk/models"
+	"github.com/A-pen-app/hire-sdk/models"
 )
 
 type Resume interface {
 	Create(ctx context.Context, userID string, content *models.ResumeContent) (*models.Resume, error)
 	Get(ctx context.Context, userID string) (*models.Resume, error)
 	Update(ctx context.Context, userID string, resume *models.ResumeContent) error
-	CreateSnapshot(ctx context.Context, userID string, chatID string) (*models.ResumeSnapshot, error)
+	CreateSnapshot(ctx context.Context, userID string) (*models.ResumeSnapshot, error)
 	GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error)
+	CreateRelation(ctx context.Context, userID string, snapshotID string, chatID string, postID string) (*models.ResumeRelation, error)
+	GetRelation(ctx context.Context, chatID string) (*models.ResumeRelation, error)
 }


### PR DESCRIPTION
- Changed module name from resume-sdk to hire-sdk in go.mod and relevant import paths.
- Updated ResumeContent fields to use pointers for optional values.
- Added ResumeRelation struct and methods for creating and retrieving relations in the store.