### PR TITLE
feat: implement SendMessage and UnsendMessage methods in chat service

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -17,4 +17,6 @@ type Chat interface {
 	Get(ctx context.Context, bundleID, chatID, userID string) (*models.ChatRoom, error)
 	GetChats(ctx context.Context, bundleID, userID string, next string, count int, options ...models.GetOptionFunc) ([]*models.ChatRoom, string, error)
 	GetChatMessages(ctx context.Context, bundleID, userID, chatID string, next string, count int) ([]*models.Message, string, error)
+	SendMessage(ctx context.Context, bundleID, userID, chatID string, options ...models.SendOptionFunc) (*models.Message, error)
+	UnsendMessage(ctx context.Context, bundleID, userID, messageID string) error
 }


### PR DESCRIPTION
- Added SendMessage method to facilitate sending messages in a chat, including error handling and content injection.
- Introduced UnsendMessage method to allow users to unsend messages, with ownership checks and idempotency considerations.
- Updated Chat interface to include the new methods for enhanced chat functionality.