### PR TITLE
feat: add Pin and Read methods to chat and resume services

### DIFF
--- a/store/chat.go
+++ b/store/chat.go
@@ -118,6 +118,21 @@ func (s *chatStore) Annotate(ctx context.Context, chatID, userID string, status 
 	return nil
 }
 
+func (s *chatStore) Pin(ctx context.Context, chatID, userID string, isPinned bool) error {
+	query := `
+	UPDATE public.chat_thread
+	SET is_pinned=?
+	WHERE chat_id=? AND sender_id=?
+	`
+	query = s.db.Rebind(query)
+	if _, err := s.db.Exec(query, isPinned, chatID, userID); err != nil {
+		logging.Errorw(ctx, "pin chat thread failed", "err", err, "chatID", chatID, "userID", userID, "isPinned", isPinned)
+		return err
+	}
+
+	return nil
+}
+
 func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, pinnedOnly bool) ([]*models.ChatRoom, error) {
 	chats := []*models.ChatRoom{}
 	if next == "" {

--- a/store/resume.go
+++ b/store/resume.go
@@ -267,3 +267,19 @@ func (s *resumeStore) GetRelation(ctx context.Context, chatID string) (*models.R
 
 	return &relation, nil
 }
+
+func (s *resumeStore) Read(ctx context.Context, chatID string) error {
+	query := `
+	UPDATE public.resume_relation
+	SET is_read=true, updated_at=?
+	WHERE chat_id=?
+	`
+	query = s.db.Rebind(query)
+	_, err := s.db.Exec(query, time.Now(), chatID)
+	if err != nil {
+		logging.Errorw(ctx, "failed to update resume relation read status", "err", err, "chatID", chatID)
+		return err
+	}
+
+	return nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -15,6 +15,7 @@ type Resume interface {
 	GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error)
 	CreateRelation(ctx context.Context, appID, userID string, snapshotID string, chatID string, postID string) (*models.ResumeRelation, error)
 	GetRelation(ctx context.Context, chatID string) (*models.ResumeRelation, error)
+	Read(ctx context.Context, chatID string) error
 }
 
 type Chat interface {
@@ -29,6 +30,7 @@ type Chat interface {
 	AddMessages(ctx context.Context, userID, chatID, receiverID string, msgs []*models.Message) error
 	EditMessage(ctx context.Context, messageID string, newStatus models.MessageStatus) error
 	Annotate(ctx context.Context, chatID, userID string, status models.ChatAnnotation) error
+	Pin(ctx context.Context, chatID, userID string, isPinned bool) error
 }
 
 type App interface {


### PR DESCRIPTION
- Implemented Pin method in chat service to update the pinned status of chat threads.
- Added Read method in resume service to mark resume relations as read, updating the timestamp accordingly.
- Updated Chat and Resume interfaces to include the new methods for enhanced functionality.