### PR TITLE
feat: add employer response time median calculation by post

### DIFF
--- a/models/chat.go
+++ b/models/chat.go
@@ -339,3 +339,8 @@ func ReplyTo(replyToMessageID string) SendOptionFunc {
 		return nil
 	}
 }
+
+type FirstMessageOption struct {
+	ChatID           string
+	ExcludedSenderID *string
+}

--- a/service/resume.go
+++ b/service/resume.go
@@ -102,15 +102,15 @@ func (s *resumeService) GetResponseMediansByPost(ctx context.Context, bundleID s
 
 	// Group relations by post_id and prepare job seeker IDs for batch query
 	postRelations := make(map[string][]*models.ResumeRelation)
-	chatIDsWithJobSeekerIDs := make(map[string]string)
+	opt := make([]models.FirstMessageOption, 0, len(relations))
 
 	for _, relation := range relations {
 		postRelations[relation.PostID] = append(postRelations[relation.PostID], relation)
-		chatIDsWithJobSeekerIDs[relation.ChatID] = relation.UserID
+		opt = append(opt, models.FirstMessageOption{ChatID: relation.ChatID, ExcludedSenderID: &relation.UserID})
 	}
 
 	// Batch fetch first employer messages for all chat rooms
-	firstMessages, err := s.c.GetFirstEmployerMessages(ctx, chatIDsWithJobSeekerIDs)
+	firstMessages, err := s.c.GetFirstMessages(ctx, opt)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get first employer messages", "err", err)
 		return nil, err

--- a/service/resume.go
+++ b/service/resume.go
@@ -123,7 +123,7 @@ func (s *resumeService) GetResponseMediansByPost(ctx context.Context, bundleID s
 
 		for _, rel := range rels {
 			// Check if employer has replied
-			if firstEmployerMessage, exists := firstMessages[rel.ChatID]; exists {
+			if firstEmployerMessage, exists := firstMessages[rel.ChatID]; exists && firstEmployerMessage != nil {
 				responseTime := firstEmployerMessage.CreatedAt.Sub(rel.CreatedAt).Hours()
 				samples = append(samples, responseTime)
 			}

--- a/service/resume.go
+++ b/service/resume.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"database/sql"
+	"sort"
+	"time"
 
 	"github.com/A-pen-app/hire-sdk/models"
 	"github.com/A-pen-app/hire-sdk/store"
@@ -12,12 +14,14 @@ import (
 type resumeService struct {
 	r store.Resume
 	a store.App
+	c store.Chat
 }
 
-func NewResume(r store.Resume, a store.App) Resume {
+func NewResume(r store.Resume, a store.App, c store.Chat) Resume {
 	return &resumeService{
 		r: r,
 		a: a,
+		c: c,
 	}
 }
 
@@ -80,4 +84,64 @@ func (s *resumeService) GetSnapshot(ctx context.Context, snapshotID string) (*mo
 		return nil, err
 	}
 	return snapshot, nil
+}
+
+func (s *resumeService) GetResponseMediansByPost(ctx context.Context, bundleID string, after time.Time) (map[string]float64, error) {
+	app, err := s.a.GetByBundleID(ctx, bundleID)
+	if err != nil {
+		logging.Errorw(ctx, "failed to get app by bundle ID", "err", err, "bundleID", bundleID)
+		return nil, err
+	}
+
+	// Get all resume relations for this app (filtered by time)
+	relations, err := s.r.ListRelations(ctx, app.ID, &after)
+	if err != nil {
+		logging.Errorw(ctx, "failed to list resume relations", "err", err, "appID", app.ID)
+		return nil, err
+	}
+
+	// Group relations by post_id and prepare job seeker IDs for batch query
+	postRelations := make(map[string][]*models.ResumeRelation)
+	chatIDsWithJobSeekerIDs := make(map[string]string)
+
+	for _, relation := range relations {
+		postRelations[relation.PostID] = append(postRelations[relation.PostID], relation)
+		chatIDsWithJobSeekerIDs[relation.ChatID] = relation.UserID
+	}
+
+	// Batch fetch first employer messages for all chat rooms
+	firstMessages, err := s.c.GetFirstEmployerMessages(ctx, chatIDsWithJobSeekerIDs)
+	if err != nil {
+		logging.Errorw(ctx, "failed to get first employer messages", "err", err)
+		return nil, err
+	}
+
+	// Calculate median response time for each post
+	result := make(map[string]float64)
+	for postID, rels := range postRelations {
+		samples := []float64{}
+
+		for _, rel := range rels {
+			// Check if employer has replied
+			if firstEmployerMessage, exists := firstMessages[rel.ChatID]; exists {
+				responseTime := firstEmployerMessage.CreatedAt.Sub(rel.CreatedAt).Hours()
+				samples = append(samples, responseTime)
+			}
+		}
+
+		// Calculate median if we have samples
+		if len(samples) > 0 {
+			sort.Float64s(samples)
+			n := len(samples)
+			if n%2 == 0 {
+				// Even number of samples: average of middle two
+				result[postID] = (samples[n/2-1] + samples[n/2]) / 2
+			} else {
+				// Odd number of samples: middle value
+				result[postID] = samples[n/2]
+			}
+		}
+	}
+
+	return result, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -12,6 +12,7 @@ type Resume interface {
 	Get(ctx context.Context, bundleID, userID string) (*models.Resume, error)
 	GetUserAppliedPostIDs(ctx context.Context, bundleID, userID string) ([]string, error)
 	GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error)
+	GetResponseMediansByPost(ctx context.Context, bundleID string, after time.Time) (map[string]float64, error)
 }
 
 type Chat interface {

--- a/store/chat.go
+++ b/store/chat.go
@@ -622,7 +622,7 @@ func (s *chatStore) GetMessages(ctx context.Context, chatID string, next string,
 
 func (s *chatStore) GetFirstEmployerMessages(ctx context.Context, chatIDsWithJobSeekerIDs map[string]string) (map[string]*models.Message, error) {
 	if len(chatIDsWithJobSeekerIDs) == 0 {
-		return make(map[string]*models.Message), nil
+		return nil, nil
 	}
 
 	// Build arrays for the query with explicit pairing
@@ -700,7 +700,7 @@ func (s *chatStore) GetFirstEmployerMessages(ctx context.Context, chatIDsWithJob
 			&msg.RefID,
 		); err != nil {
 			logging.Errorw(ctx, "failed to scan message", "err", err)
-			continue
+			return nil, err
 		}
 		result[msg.ChatID] = &msg
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -30,7 +30,7 @@ type Chat interface {
 	GetMessage(ctx context.Context, messageID string) (*models.Message, error)
 	GetMessages(ctx context.Context, chatID string, next string, count int) ([]*models.Message, error)
 	GetNewMessages(ctx context.Context, chatID string, after time.Time) ([]*models.Message, error)
-	GetFirstEmployerMessages(ctx context.Context, chatIDsWithJobSeekerIDs map[string]string) (map[string]*models.Message, error)
+	GetFirstMessages(ctx context.Context, opt []models.FirstMessageOption) (map[string]*models.Message, error)
 	AddMessage(ctx context.Context, userID, chatID, receiverID string, typ models.MessageType, body *string, mediaIDs []string, replyToMessageID *string, referenceID *string) (string, error)
 	AddMessages(ctx context.Context, userID, chatID, receiverID string, msgs []*models.Message) error
 	EditMessage(ctx context.Context, messageID string, newStatus models.MessageStatus) error

--- a/store/store.go
+++ b/store/store.go
@@ -16,6 +16,7 @@ type Resume interface {
 	GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error)
 	CreateRelation(ctx context.Context, appID, userID string, snapshotID string, chatID string, postID string, status models.ResumeStatus) (*models.ResumeRelation, error)
 	GetRelation(ctx context.Context, opts ...models.GetRelationOptionFunc) (*models.ResumeRelation, error)
+	ListRelations(ctx context.Context, appID string, after *time.Time) ([]*models.ResumeRelation, error)
 	Read(ctx context.Context, snapshotID string) error
 	UpdateRelationStatus(ctx context.Context, snapshotID string, status models.ResumeStatus) error
 	UpdateRelationListStatus(ctx context.Context, postIDs []string, status models.ResumeStatus) error
@@ -29,6 +30,7 @@ type Chat interface {
 	GetMessage(ctx context.Context, messageID string) (*models.Message, error)
 	GetMessages(ctx context.Context, chatID string, next string, count int) ([]*models.Message, error)
 	GetNewMessages(ctx context.Context, chatID string, after time.Time) ([]*models.Message, error)
+	GetFirstEmployerMessages(ctx context.Context, chatIDsWithJobSeekerIDs map[string]string) (map[string]*models.Message, error)
 	AddMessage(ctx context.Context, userID, chatID, receiverID string, typ models.MessageType, body *string, mediaIDs []string, replyToMessageID *string, referenceID *string) (string, error)
 	AddMessages(ctx context.Context, userID, chatID, receiverID string, msgs []*models.Message) error
 	EditMessage(ctx context.Context, messageID string, newStatus models.MessageStatus) error


### PR DESCRIPTION
- Add GetResponseMediansByPost to calculate median response time for each job post
- Implement batch query GetFirstEmployerMessages for better performance
- Add time filtering to ListRelations at store layer
- Rename from excluded senders to job seeker IDs for clarity
- Use business-oriented naming (employer/job seeker) throughout
- Return median in hours as float64