### PR TITLE
feat: experience fields + preferred-location dual-write (PS-3132)

### DIFF
--- a/models/business_card.go
+++ b/models/business_card.go
@@ -19,6 +19,21 @@ type BusinessCardContent struct {
 	// for pharmacist and nurse
 	CurrentOrganization *string `json:"current_organization,omitempty"`
 	CurrentJobTitle     *string `json:"current_job_title,omitempty"`
+
+	// ExperienceYears is apen-only, mirroring user.experience_years in apen's
+	// main DB with its sentinel encoding: 0 = less than 1 year (also
+	// no-experience and students), 21 = more than 20 years. Never render the
+	// raw value — decode via FormatExperienceYears.
+	ExperienceYears *int `json:"experience_years,omitempty"`
+
+	// ExperienceRange is the nurse / phar range-based tenure; mutually
+	// exclusive with ExperienceYears.
+	ExperienceRange *ExperienceRange `json:"experience_range,omitempty"`
+
+	// PreferredLocations is dual-written with the resume's preferred_locations:
+	// updating either surface syncs the other in one transaction (see
+	// store.BusinessCard.Upsert and store.Resume.Update).
+	PreferredLocations []string `json:"preferred_locations,omitempty"`
 }
 
 // Value implements the driver.Valuer interface for inserting as jsonb

--- a/models/experience.go
+++ b/models/experience.go
@@ -1,0 +1,61 @@
+package models
+
+import "strconv"
+
+// Sentinel values for the apen absolute-tenure encoding used by
+// BusinessCardContent.ExperienceYears (and user.experience_years in apen's
+// main DB). Values in between are literal year counts.
+const (
+	ExperienceYearsLessThanOne = 0  // "1年以下"; also covers no-experience and students
+	ExperienceYearsTwentyPlus  = 21 // "20年以上"; never a literal year count
+)
+
+// FormatExperienceYears decodes the sentinel encoding into the display
+// string. All render paths (chat card, snapshots) must go through this
+// instead of printing the raw value.
+func FormatExperienceYears(v int) string {
+	switch {
+	case v <= ExperienceYearsLessThanOne:
+		return "1年以下"
+	case v >= ExperienceYearsTwentyPlus:
+		return "20年以上"
+	default:
+		return strconv.Itoa(v) + "年"
+	}
+}
+
+// ExperienceRange is the nurse / phar range-based tenure stored in
+// BusinessCardContent.ExperienceRange (and user.experience_range in their
+// main DBs). Stored as strings so snapshots stay self-describing.
+type ExperienceRange string
+
+const (
+	ExperienceRangeLessThanOne  ExperienceRange = "LESS_THAN_ONE"  // 1年以下
+	ExperienceRangeOneToThree   ExperienceRange = "ONE_TO_THREE"   // 1-3年
+	ExperienceRangeThreeToFive  ExperienceRange = "THREE_TO_FIVE"  // 3-5年
+	ExperienceRangeFiveToTen    ExperienceRange = "FIVE_TO_TEN"    // 5-10年
+	ExperienceRangeTenToFifteen ExperienceRange = "TEN_TO_FIFTEEN" // 10-15年
+	ExperienceRangeFifteenPlus  ExperienceRange = "FIFTEEN_PLUS"   // 15年以上
+)
+
+func (e ExperienceRange) Chinese() string {
+	switch e {
+	case ExperienceRangeLessThanOne:
+		return "1年以下"
+	case ExperienceRangeOneToThree:
+		return "1-3年"
+	case ExperienceRangeThreeToFive:
+		return "3-5年"
+	case ExperienceRangeFiveToTen:
+		return "5-10年"
+	case ExperienceRangeTenToFifteen:
+		return "10-15年"
+	case ExperienceRangeFifteenPlus:
+		return "15年以上"
+	}
+	return ""
+}
+
+func ValidateExperienceRange(e ExperienceRange) bool {
+	return e.Chinese() != ""
+}

--- a/models/experience_test.go
+++ b/models/experience_test.go
@@ -1,0 +1,92 @@
+package models
+
+import "testing"
+
+// Locks the legacy 12-step ordinals in place: existing rows in
+// social_business_card.year_of_experience and hire DB hospital_experience
+// store these values, so any shift silently corrupts every stored tenure.
+func TestYearOfExperienceOrdinalsAreStable(t *testing.T) {
+	want := []struct {
+		value   YearOfExperienceType
+		ordinal int
+		chinese string
+	}{
+		{YearOfExperienceNone, 0, "無經驗"},
+		{YearOfExperienceLessThanOne, 1, "1年以下"},
+		{YearOfExperienceOneToTwo, 2, "1年 ~ 2年"},
+		{YearOfExperienceTwoToThree, 3, "2年 ~ 3年"},
+		{YearOfExperienceThreeToFour, 4, "3年 ~ 4年"},
+		{YearOfExperienceFourToFive, 5, "4年 ~ 5年"},
+		{YearOfExperienceFiveToSix, 6, "5年 ~ 6年"},
+		{YearOfExperienceSixToSeven, 7, "6年 ~ 7年"},
+		{YearOfExperienceSevenToEight, 8, "7年 ~ 8年"},
+		{YearOfExperienceEightToNine, 9, "8年 ~ 9年"},
+		{YearOfExperienceNineToTen, 10, "9年 ~ 10年"},
+		{YearOfExperienceMoreThanTen, 11, "10年以上"},
+	}
+	for _, w := range want {
+		if int(w.value) != w.ordinal {
+			t.Errorf("ordinal shifted: %s = %d, want %d", w.chinese, w.value, w.ordinal)
+		}
+		if got := w.value.Chinese(); got != w.chinese {
+			t.Errorf("Chinese(%d) = %q, want %q", w.value, got, w.chinese)
+		}
+	}
+}
+
+func TestValidateYearOfExperience(t *testing.T) {
+	for y := YearOfExperienceNone; y <= YearOfExperienceMoreThanTen; y++ {
+		if !ValidateYearOfExperience(y) {
+			t.Errorf("ValidateYearOfExperience(%d) = false, want true", y)
+		}
+	}
+	for _, y := range []YearOfExperienceType{-1, 12, 99} {
+		if ValidateYearOfExperience(y) {
+			t.Errorf("ValidateYearOfExperience(%d) = true, want false", y)
+		}
+	}
+}
+
+func TestFormatExperienceYears(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{ExperienceYearsLessThanOne, "1年以下"},
+		{1, "1年"},
+		{7, "7年"},
+		{20, "20年"},
+		{ExperienceYearsTwentyPlus, "20年以上"},
+		{-1, "1年以下"},  // defensive: below range clamps to the low sentinel
+		{30, "20年以上"}, // defensive: above range clamps to the high sentinel
+	}
+	for _, c := range cases {
+		if got := FormatExperienceYears(c.in); got != c.want {
+			t.Errorf("FormatExperienceYears(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExperienceRange(t *testing.T) {
+	want := map[ExperienceRange]string{
+		ExperienceRangeLessThanOne:  "1年以下",
+		ExperienceRangeOneToThree:   "1-3年",
+		ExperienceRangeThreeToFive:  "3-5年",
+		ExperienceRangeFiveToTen:    "5-10年",
+		ExperienceRangeTenToFifteen: "10-15年",
+		ExperienceRangeFifteenPlus:  "15年以上",
+	}
+	for r, chinese := range want {
+		if !ValidateExperienceRange(r) {
+			t.Errorf("ValidateExperienceRange(%q) = false, want true", r)
+		}
+		if got := r.Chinese(); got != chinese {
+			t.Errorf("Chinese(%q) = %q, want %q", r, got, chinese)
+		}
+	}
+	for _, r := range []ExperienceRange{"", "less_than_one", "TWENTY_PLUS"} {
+		if ValidateExperienceRange(r) {
+			t.Errorf("ValidateExperienceRange(%q) = true, want false", r)
+		}
+	}
+}

--- a/models/resume.go
+++ b/models/resume.go
@@ -44,51 +44,61 @@ type HospitalExperience struct {
 	YearOfExperience YearOfExperienceType `json:"year_of_experience"`
 }
 
+// YearOfExperienceType is the legacy 12-step tenure ordinal used by the
+// resume's HospitalExperience (and apen's social_business_card rows).
+//
+// The iota order below must NEVER change: existing DB rows store these
+// ordinals, so reordering silently shifts every stored tenure.
 type YearOfExperienceType int
 
 const (
-	yearOfExperienceType_None YearOfExperienceType = iota
-	yearOfExperienceType_LessThanOne
-	yearOfExperienceType_OneToTwo
-	yearOfExperienceType_TwoToThree
-	yearOfExperienceType_ThreeToFour
-	yearOfExperienceType_FourToFive
-	yearOfExperienceType_FiveToSix
-	yearOfExperienceType_SixToSeven
-	yearOfExperienceType_SevenToEight
-	yearOfExperienceType_EightToNine
-	yearOfExperienceType_NineToTen
-	yearOfExperienceType_MoreThanTen
+	YearOfExperienceNone YearOfExperienceType = iota
+	YearOfExperienceLessThanOne
+	YearOfExperienceOneToTwo
+	YearOfExperienceTwoToThree
+	YearOfExperienceThreeToFour
+	YearOfExperienceFourToFive
+	YearOfExperienceFiveToSix
+	YearOfExperienceSixToSeven
+	YearOfExperienceSevenToEight
+	YearOfExperienceEightToNine
+	YearOfExperienceNineToTen
+	YearOfExperienceMoreThanTen
 )
 
 func (y YearOfExperienceType) Chinese() string {
 	switch y {
-	case yearOfExperienceType_None:
+	case YearOfExperienceNone:
 		return "無經驗"
-	case yearOfExperienceType_LessThanOne:
+	case YearOfExperienceLessThanOne:
 		return "1年以下"
-	case yearOfExperienceType_OneToTwo:
+	case YearOfExperienceOneToTwo:
 		return "1年 ~ 2年"
-	case yearOfExperienceType_TwoToThree:
+	case YearOfExperienceTwoToThree:
 		return "2年 ~ 3年"
-	case yearOfExperienceType_ThreeToFour:
+	case YearOfExperienceThreeToFour:
 		return "3年 ~ 4年"
-	case yearOfExperienceType_FourToFive:
+	case YearOfExperienceFourToFive:
 		return "4年 ~ 5年"
-	case yearOfExperienceType_FiveToSix:
+	case YearOfExperienceFiveToSix:
 		return "5年 ~ 6年"
-	case yearOfExperienceType_SixToSeven:
+	case YearOfExperienceSixToSeven:
 		return "6年 ~ 7年"
-	case yearOfExperienceType_SevenToEight:
+	case YearOfExperienceSevenToEight:
 		return "7年 ~ 8年"
-	case yearOfExperienceType_EightToNine:
+	case YearOfExperienceEightToNine:
 		return "8年 ~ 9年"
-	case yearOfExperienceType_NineToTen:
+	case YearOfExperienceNineToTen:
 		return "9年 ~ 10年"
-	case yearOfExperienceType_MoreThanTen:
+	case YearOfExperienceMoreThanTen:
 		return "10年以上"
 	}
 	return ""
+}
+
+// ValidateYearOfExperience reports whether y is one of the defined ordinals.
+func ValidateYearOfExperience(y YearOfExperienceType) bool {
+	return y >= YearOfExperienceNone && y <= YearOfExperienceMoreThanTen
 }
 
 type ContactTime struct {

--- a/service/business_card.go
+++ b/service/business_card.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/A-pen-app/hire-sdk/models"
 	"github.com/A-pen-app/hire-sdk/store"
@@ -66,6 +67,9 @@ func (s *businessCardService) Get(ctx context.Context, bundleID, userID string) 
 // store.BusinessCard.Upsert); if no resume exists, one is seeded from the
 // card data.
 func (s *businessCardService) Update(ctx context.Context, bundleID, userID string, card *models.BusinessCardContent) (*models.BusinessCardContent, error) {
+	if card == nil {
+		return nil, errors.New("business card content is nil")
+	}
 	app, err := s.a.GetByBundleID(ctx, bundleID)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get app by bundle ID", "err", err, "bundleID", bundleID)

--- a/service/business_card.go
+++ b/service/business_card.go
@@ -51,17 +51,20 @@ func (s *businessCardService) Get(ctx context.Context, bundleID, userID string) 
 
 	if resume != nil && resume.Content != nil {
 		return &models.BusinessCardContent{
-			RealName:    resume.Content.RealName,
-			Position:    resume.Content.Position,
-			Departments: resume.Content.Departments,
+			RealName:           resume.Content.RealName,
+			Position:           resume.Content.Position,
+			Departments:        resume.Content.Departments,
+			PreferredLocations: resume.Content.PreferredLocations,
 		}, nil
 	}
 
 	return &models.BusinessCardContent{}, nil
 }
 
-// Update overwrites the user's business card.
-// If no resume exists, also creates one with the card data.
+// Update overwrites the user's business card. An existing resume gets its
+// preferred_locations synced inside the upsert transaction (see
+// store.BusinessCard.Upsert); if no resume exists, one is seeded from the
+// card data.
 func (s *businessCardService) Update(ctx context.Context, bundleID, userID string, card *models.BusinessCardContent) (*models.BusinessCardContent, error) {
 	app, err := s.a.GetByBundleID(ctx, bundleID)
 	if err != nil {
@@ -82,6 +85,7 @@ func (s *businessCardService) Update(ctx context.Context, bundleID, userID strin
 			Departments:         card.Departments,
 			CurrentOrganization: card.CurrentOrganization,
 			CurrentJobTitle:     card.CurrentJobTitle,
+			PreferredLocations:  card.PreferredLocations,
 		}
 		if _, err := s.r.Create(ctx, app.ID, userID, content); err != nil {
 			logging.Errorw(ctx, "failed to seed resume from card", "err", err, "userID", userID)

--- a/store/business_card.go
+++ b/store/business_card.go
@@ -89,7 +89,7 @@ func (s *businessCard) Upsert(ctx context.Context, appID, userID string, card *m
 		// No-op when the user has no resume yet; the service layer seeds one.
 		query := `
 		UPDATE public.resume
-		SET content = jsonb_set(content, '{preferred_locations}', ?::jsonb),
+		SET content = jsonb_set(COALESCE(content, '{}'::jsonb), '{preferred_locations}', ?::jsonb),
 			updated_at = ?
 		WHERE app_id = ? AND user_id = ?
 		`

--- a/store/business_card.go
+++ b/store/business_card.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/A-pen-app/hire-sdk/models"
@@ -49,8 +50,20 @@ func (s *businessCard) Get(ctx context.Context, appID, userID string) (*models.B
 	return &record, nil
 }
 
+// Upsert writes the user's business card. PreferredLocations is dual-written:
+// when the card carries a non-nil value, the user's resume (if any) gets its
+// preferred_locations replaced in the same transaction so the two surfaces
+// stay in sync. A nil value leaves the resume untouched, so callers unaware
+// of locations can't wipe them.
 func (s *businessCard) Upsert(ctx context.Context, appID, userID string, card *models.BusinessCardContent) error {
 	now := time.Now()
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		logging.Errorw(ctx, "failed to begin business card upsert tx", "err", err, "appID", appID, "userID", userID)
+		return err
+	}
+	defer tx.Rollback()
 
 	query := `
 	INSERT INTO public.business_card (id, app_id, user_id, content, created_at, updated_at)
@@ -59,14 +72,38 @@ func (s *businessCard) Upsert(ctx context.Context, appID, userID string, card *m
 		content = EXCLUDED.content,
 		updated_at = EXCLUDED.updated_at
 	`
-	query = s.db.Rebind(query)
+	query = tx.Rebind(query)
 
 	id := uuid.New().String()
-	if _, err := s.db.ExecContext(ctx, query, id, appID, userID, card, now, now); err != nil {
+	if _, err := tx.ExecContext(ctx, query, id, appID, userID, card, now, now); err != nil {
 		logging.Errorw(ctx, "failed to upsert business card", "err", err, "appID", appID, "userID", userID)
 		return err
 	}
 
+	if card != nil && card.PreferredLocations != nil {
+		locations, err := json.Marshal(card.PreferredLocations)
+		if err != nil {
+			logging.Errorw(ctx, "failed to marshal preferred locations", "err", err, "appID", appID, "userID", userID)
+			return err
+		}
+		// No-op when the user has no resume yet; the service layer seeds one.
+		query := `
+		UPDATE public.resume
+		SET content = jsonb_set(content, '{preferred_locations}', ?::jsonb),
+			updated_at = ?
+		WHERE app_id = ? AND user_id = ?
+		`
+		query = tx.Rebind(query)
+		if _, err := tx.ExecContext(ctx, query, string(locations), now, appID, userID); err != nil {
+			logging.Errorw(ctx, "failed to sync preferred locations to resume", "err", err, "appID", appID, "userID", userID)
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		logging.Errorw(ctx, "failed to commit business card upsert tx", "err", err, "appID", appID, "userID", userID)
+		return err
+	}
 	return nil
 }
 

--- a/store/resume.go
+++ b/store/resume.go
@@ -158,7 +158,7 @@ func (s *resumeStore) Update(ctx context.Context, appID, userID string, content 
 		// back to the resume anyway).
 		query := `
 		UPDATE public.business_card
-		SET content = jsonb_set(content, '{preferred_locations}', ?::jsonb),
+		SET content = jsonb_set(COALESCE(content, '{}'::jsonb), '{preferred_locations}', ?::jsonb),
 			updated_at = ?
 		WHERE app_id = ? AND user_id = ?
 		`

--- a/store/resume.go
+++ b/store/resume.go
@@ -135,19 +135,13 @@ func (s *resumeStore) Update(ctx context.Context, appID, userID string, content 
 	}
 	defer tx.Rollback()
 
-	query := `
-	UPDATE public.resume
-	SET	content = ?,
-		updated_at = ?
-	WHERE app_id = ? AND user_id = ?
-	`
-	query = tx.Rebind(query)
-
-	if _, err := tx.ExecContext(ctx, query, content, now, appID, userID); err != nil {
-		logging.Errorw(ctx, "failed to update resume", "err", err, "appID", appID, "userID", userID)
-		return err
-	}
-
+	// Mirror preferred_locations to the business card BEFORE updating the
+	// resume, so this path takes row locks in business_card → resume order —
+	// the same order as BusinessCard.Upsert. Doing the resume UPDATE first
+	// would give the two dual-write paths opposite lock orders, and since the
+	// locks are held until COMMIT inside the tx, concurrent writes for the same
+	// user could AB-BA deadlock (SQLSTATE 40P01). The two statements are order-
+	// independent for the result: the mirror doesn't depend on the resume write.
 	if content != nil {
 		locations, err := json.Marshal(content.PreferredLocations)
 		if err != nil {
@@ -167,6 +161,19 @@ func (s *resumeStore) Update(ctx context.Context, appID, userID string, content 
 			logging.Errorw(ctx, "failed to sync preferred locations to business card", "err", err, "appID", appID, "userID", userID)
 			return err
 		}
+	}
+
+	query := `
+	UPDATE public.resume
+	SET	content = ?,
+		updated_at = ?
+	WHERE app_id = ? AND user_id = ?
+	`
+	query = tx.Rebind(query)
+
+	if _, err := tx.ExecContext(ctx, query, content, now, appID, userID); err != nil {
+		logging.Errorw(ctx, "failed to update resume", "err", err, "appID", appID, "userID", userID)
+		return err
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/store/resume.go
+++ b/store/resume.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -119,21 +120,59 @@ func (s *resumeStore) GetUserAppliedPostIDs(ctx context.Context, appID, userID s
 	return postIDs, nil
 }
 
+// Update replaces the resume content. PreferredLocations is dual-written:
+// the user's business card (if any) gets its preferred_locations replaced in
+// the same transaction so the two surfaces stay in sync. The resume is a
+// full-replace surface, so the card mirrors whatever the resume now holds —
+// including null when the locations were cleared.
 func (s *resumeStore) Update(ctx context.Context, appID, userID string, content *models.ResumeContent) error {
+	now := time.Now()
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		logging.Errorw(ctx, "failed to begin resume update tx", "err", err, "appID", appID, "userID", userID)
+		return err
+	}
+	defer tx.Rollback()
+
 	query := `
-	UPDATE public.resume 
+	UPDATE public.resume
 	SET	content = ?,
 		updated_at = ?
 	WHERE app_id = ? AND user_id = ?
 	`
-	query = s.db.Rebind(query)
+	query = tx.Rebind(query)
 
-	_, err := s.db.Exec(query, content, time.Now(), appID, userID)
-	if err != nil {
+	if _, err := tx.ExecContext(ctx, query, content, now, appID, userID); err != nil {
 		logging.Errorw(ctx, "failed to update resume", "err", err, "appID", appID, "userID", userID)
 		return err
 	}
 
+	if content != nil {
+		locations, err := json.Marshal(content.PreferredLocations)
+		if err != nil {
+			logging.Errorw(ctx, "failed to marshal preferred locations", "err", err, "appID", appID, "userID", userID)
+			return err
+		}
+		// No-op when the user has no business card yet (the card view falls
+		// back to the resume anyway).
+		query := `
+		UPDATE public.business_card
+		SET content = jsonb_set(content, '{preferred_locations}', ?::jsonb),
+			updated_at = ?
+		WHERE app_id = ? AND user_id = ?
+		`
+		query = tx.Rebind(query)
+		if _, err := tx.ExecContext(ctx, query, string(locations), now, appID, userID); err != nil {
+			logging.Errorw(ctx, "failed to sync preferred locations to business card", "err", err, "appID", appID, "userID", userID)
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		logging.Errorw(ctx, "failed to commit resume update tx", "err", err, "appID", appID, "userID", userID)
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

J2（編輯求職意向）的 hire-sdk 前置改動，供 apen / nurse / phar 三端使用。對應 [PS-3132](https://a-pen.atlassian.net/browse/PS-3132)。

### `BusinessCardContent` 新欄位
- `experience_years` (*int)：**apen 專用**絕對年資，沿用主 DB `user.experience_years` 的 sentinel 編碼（`0` = 1年以下、`21` = 20年以上）。讀取端一律透過 `FormatExperienceYears` 解碼，不可直接渲染原始值。
- `experience_range` (*ExperienceRange)：**nurse / phar 專用**區間年資（6 階字串 enum），與 `experience_years` 互斥。
- `preferred_locations` ([]string)：與履歷的 `preferred_locations` 雙寫連動。

### 雙寫（同一交易）
兩張表同在 hireDB，改在 store 層以 tx 原子雙寫，**interface 簽名不變**：
- `BusinessCard.Upsert`：名片帶 non-nil `PreferredLocations` 時，同交易更新既有履歷的 `preferred_locations`（`jsonb_set`）。nil 不動履歷——不認識此欄位的舊呼叫端不會誤清資料。
- `Resume.Update`：履歷是 full-replace 面，同交易把值鏡射到名片（含清空）。
- `service.BusinessCard.Update` 的履歷 seed 與 `Get` 的履歷 fallback 補上 `PreferredLocations`。

### 既有 `YearOfExperienceType` 整理
- 12 階常數改為匯出（`YearOfExperienceNone` … `YearOfExperienceMoreThanTen`）+ 新增 `ValidateYearOfExperience`。
- 新增測試**鎖定 iota 順序與 `Chinese()` 字串**——既存 `social_business_card.year_of_experience` 與 hireDB `hospital_experience` 都存 ordinal，位移即集體錯位。

## 不做的事
- 履歷**不**新增年資欄位（年資連動範圍是個人資料/求職名片/社交名片，不含履歷）。
- `business_card_snapshot` / `resume` snapshot 維持配對當下凍結，不隨後續更新。

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./models/`（ordinal 鎖定、FormatExperienceYears、ExperienceRange）
- [ ] 合併後發版，apen J2 stacked PR 升版驗證雙向同步（PATCH 名片 → GET 履歷一致；PATCH 履歷 → GET 名片一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-3132]: https://penpeer.atlassian.net/browse/PS-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ