### PR TITLE
feat(chat): archive a chat room

### DIFF
--- a/migrations/20260728_add_chat_thread_hidden_cleared.sql
+++ b/migrations/20260728_add_chat_thread_hidden_cleared.sql
@@ -1,0 +1,26 @@
+-- Applies to: hiring DB
+--
+-- Per-user chat room visibility: archive and delete.
+--
+-- Both columns live on chat_thread, which has one row per participant, so writing one
+-- participant's row never changes what the other sees. See docs/chat_visibility.md.
+--
+--   hidden_at  archive timestamp. The room disappears from this user's list until an
+--              activity strictly later than hidden_at occurs. chat.updated_at only
+--              moves when a message is added, so a new message restores the room with
+--              no extra write on the send path.
+--   cleared_at delete cutoff. This user only ever sees messages created strictly after
+--              it. Never reset by later messages. Wired up in stage 2; added here so
+--              the two visibility columns land together.
+--
+-- Nullable, no default, no backfill: existing rows read as "never archived, never
+-- cleared", which is the behaviour they have today. Idempotent and zero-downtime.
+--
+-- The hiring DB is shared by apen / nurse / phar via chat.app_id, so this runs once
+-- and takes effect for all three apps.
+--
+-- WARNING: there is no migration runner. Apply this by hand (DBA / Cloud SQL console)
+-- BEFORE deploying the code that depends on it.
+ALTER TABLE public.chat_thread
+    ADD COLUMN IF NOT EXISTS hidden_at  timestamptz,
+    ADD COLUMN IF NOT EXISTS cleared_at timestamptz;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,25 @@
+# migrations/
+
+Hand-written DDL for the **hiring** database, versioned for review and audit.
+
+**There is no migration runner.** The production schema is managed externally — apply
+these files manually (DBA / Cloud SQL console) **before** deploying the code that
+depends on them, and before bumping the `hire-sdk` version in the API repos. Files are
+named `YYYYMMDD_<ticket>_<summary>.sql`, with `<ticket>` omitted when there isn't one,
+and must be idempotent (`IF NOT EXISTS` / `IF EXISTS`) so re-running is safe.
+
+The hiring database is **shared by apen, nurse and phar** through `chat.app_id`; there
+is one physical database, so each file is applied once and takes effect for all three
+apps. This is why the DDL lives here rather than being copied into the three API repos:
+their `migrations/` directories cover their own main databases only.
+
+Deployment order for a schema change that this SDK depends on:
+
+1. Apply the SQL to the hiring database
+2. Merge and tag `hire-sdk`
+3. Bump `go.mod` in `apen-api`, `nurse-api` and `phar-api` — **all three together**,
+   or older code keeps running older logic against the same database
+
+| File | Ticket | Applies to |
+|---|---|---|
+| `20260728_add_chat_thread_hidden_cleared.sql` | — | hiring DB |

--- a/models/chat.go
+++ b/models/chat.go
@@ -239,6 +239,13 @@ type ChatRoom struct {
 	ResumeSnapshot         *ChatResumeSnapshot   `json:"resume_snapshot" db:"-"`
 	BusinessCardSnapshot   *BusinessCardSnapshot `json:"business_card_snapshot" db:"-"`
 	HireContact            *HireContact          `json:"hire_contact" db:"hire_contact"`
+
+	// HiddenAt is when this user archived the room, ClearedAt when they deleted its
+	// history. Both are per-user and never exposed to the client — the room simply
+	// stops being listed, and pre-cutoff messages simply stop being returned. See
+	// docs/chat_visibility.md and models/chat_visibility.go.
+	HiddenAt  *time.Time `json:"-" db:"hidden_at"`
+	ClearedAt *time.Time `json:"-" db:"cleared_at"`
 }
 
 func (p ChatRoom) Feedtype() feedmodel.FeedType {

--- a/models/chat_visibility.go
+++ b/models/chat_visibility.go
@@ -1,0 +1,86 @@
+package models
+
+import "time"
+
+// Chat room visibility rules — archive (hidden_at) and delete (cleared_at).
+//
+// The rules below are specified in docs/chat_visibility.md and are shared verbatim
+// with megaphone and the apen/nurse/phar API repos. All three implementations must
+// behave identically; only the storage mechanism differs. Keep this file, the SQL in
+// store/chat.go, and the spec document in sync.
+//
+// Both hidden_at and cleared_at live on the per-user chat_thread row, which is what
+// makes archive and delete one-sided: writing one participant's row never affects the
+// other's.
+
+// IsChatHidden reports whether a chat room is hidden from the owner of a chat_thread
+// row — rule R1.
+//
+// A room stays hidden until an activity strictly later than hiddenAt occurs. Because
+// hire-sdk only ever bumps chat.updated_at when a message is added (store/chat.go,
+// AddMessage and AddMessages — the other UPDATE public.chat statements set a single
+// unrelated column), passing that column as lastActivityAt makes a new message
+// un-archive the room automatically, with no extra write on the send path.
+//
+// The comparison is deliberately strict: an activity timestamp exactly equal to
+// hiddenAt leaves the room hidden (test case CHAT-306).
+func IsChatHidden(hiddenAt *time.Time, lastActivityAt time.Time) bool {
+	if hiddenAt == nil {
+		return false
+	}
+	return !lastActivityAt.After(*hiddenAt)
+}
+
+// IsAfterCutoff reports whether a timestamp falls after a delete cutoff — the
+// timestamp half of rule R2.
+//
+// A nil clearedAt means the user never deleted the room, so everything is after the
+// cutoff. The comparison is strict: a message created exactly at the cutoff is not
+// after it and stays hidden (test case CHAT-305).
+func IsAfterCutoff(createdAt time.Time, clearedAt *time.Time) bool {
+	if clearedAt == nil {
+		return true
+	}
+	return createdAt.After(*clearedAt)
+}
+
+// IsMessageDeletedFor reports whether a message was deleted by the given viewer
+// through the per-message delete flow.
+//
+// message.status is a bitmask holding one flag per side, so the same row can be
+// deleted by the sender, by the receiver, or by both, and each side only ever hides
+// its own copy.
+func IsMessageDeletedFor(status MessageStatus, senderID, viewerID string) bool {
+	if status.HasOneOf(DeletedBySender) && viewerID == senderID {
+		return true
+	}
+	return status.HasOneOf(DeletedByReceiver) && viewerID != senderID
+}
+
+// IsMessageVisibleFor reports whether a message should appear in the viewer's message
+// list — rule R2.
+//
+// Unsent messages count as visible: the list still renders a "message unsent"
+// placeholder, so the caller wipes their content rather than dropping the row. Use
+// IsLastMessageVisibleFor for the chat-list preview, which drops them instead.
+func IsMessageVisibleFor(msg *Message, viewerID string, clearedAt *time.Time) bool {
+	if msg == nil {
+		return false
+	}
+	if !IsAfterCutoff(msg.CreatedAt, clearedAt) {
+		return false
+	}
+	return !IsMessageDeletedFor(msg.Status, msg.SenderID, viewerID)
+}
+
+// IsLastMessageVisibleFor reports whether a message may be used as the viewer's
+// chat-list preview.
+//
+// This is IsMessageVisibleFor plus "unsent messages have nothing to preview", matching
+// the behaviour the service layer already had before these rules were extracted.
+func IsLastMessageVisibleFor(msg *Message, viewerID string, clearedAt *time.Time) bool {
+	if !IsMessageVisibleFor(msg, viewerID, clearedAt) {
+		return false
+	}
+	return !msg.Status.HasOneOf(Unsent)
+}

--- a/models/chat_visibility_test.go
+++ b/models/chat_visibility_test.go
@@ -1,0 +1,168 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+// These tests lock the archive / delete visibility rules (R1, R2) defined in
+// docs/chat_visibility.md. The same rules are implemented in hire-sdk and in the
+// apen/nurse/phar API repos, and the equivalent test files there must stay in
+// agreement with this one — they are each other's consistency baseline.
+
+var (
+	tBase  = time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	tEarly = tBase.Add(-time.Hour)
+	tLate  = tBase.Add(time.Hour)
+)
+
+func ptr(t time.Time) *time.Time { return &t }
+
+func TestIsChatHidden(t *testing.T) {
+	cases := []struct {
+		name           string
+		hiddenAt       *time.Time
+		lastActivityAt time.Time
+		want           bool
+	}{
+		{"never archived", nil, tBase, false},
+		{"archived, no activity since", ptr(tBase), tEarly, true},
+		{"archived, newer message restores it", ptr(tBase), tLate, false},
+		// CHAT-306: restoring requires an activity strictly later than the archive
+		// timestamp. Equal timestamps keep the room hidden.
+		{"archived, activity exactly at the archive time", ptr(tBase), tBase, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsChatHidden(c.hiddenAt, c.lastActivityAt); got != c.want {
+				t.Errorf("IsChatHidden() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsAfterCutoff(t *testing.T) {
+	cases := []struct {
+		name      string
+		createdAt time.Time
+		clearedAt *time.Time
+		want      bool
+	}{
+		{"never deleted", tEarly, nil, true},
+		{"created before the cutoff", tEarly, ptr(tBase), false},
+		{"created after the cutoff", tLate, ptr(tBase), true},
+		// CHAT-305: a message created exactly at the cutoff is not after it.
+		{"created exactly at the cutoff", tBase, ptr(tBase), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsAfterCutoff(c.createdAt, c.clearedAt); got != c.want {
+				t.Errorf("IsAfterCutoff() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsMessageDeletedFor(t *testing.T) {
+	const sender, receiver = "user-a", "user-b"
+
+	cases := []struct {
+		name     string
+		status   MessageStatus
+		viewerID string
+		want     bool
+	}{
+		{"normal, sender views", Normal, sender, false},
+		{"normal, receiver views", Normal, receiver, false},
+
+		{"deleted by sender, sender views", DeletedBySender, sender, true},
+		{"deleted by sender, receiver still sees it", DeletedBySender, receiver, false},
+
+		{"deleted by receiver, receiver views", DeletedByReceiver, receiver, true},
+		{"deleted by receiver, sender still sees it", DeletedByReceiver, sender, false},
+
+		{"deleted by both, sender views", DeletedBySender | DeletedByReceiver, sender, true},
+		{"deleted by both, receiver views", DeletedBySender | DeletedByReceiver, receiver, true},
+
+		// Unsent is a separate concern: it hides the content from both sides but is
+		// not a per-viewer delete.
+		{"unsent, sender views", Unsent, sender, false},
+		{"unsent, receiver views", Unsent, receiver, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsMessageDeletedFor(c.status, sender, c.viewerID); got != c.want {
+				t.Errorf("IsMessageDeletedFor() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsMessageVisibleFor(t *testing.T) {
+	const sender, receiver = "user-a", "user-b"
+
+	msg := func(status MessageStatus, createdAt time.Time) *Message {
+		return &Message{SenderID: sender, Status: status, CreatedAt: createdAt}
+	}
+
+	cases := []struct {
+		name      string
+		msg       *Message
+		viewerID  string
+		clearedAt *time.Time
+		want      bool
+	}{
+		{"nil message", nil, receiver, nil, false},
+		{"normal message, no cutoff", msg(Normal, tBase), receiver, nil, true},
+
+		{"before the cutoff", msg(Normal, tEarly), receiver, ptr(tBase), false},
+		{"after the cutoff", msg(Normal, tLate), receiver, ptr(tBase), true},
+		{"exactly at the cutoff", msg(Normal, tBase), receiver, ptr(tBase), false},
+
+		{"deleted for this viewer", msg(DeletedByReceiver, tLate), receiver, ptr(tBase), false},
+		{"deleted for the other side only", msg(DeletedBySender, tLate), receiver, ptr(tBase), true},
+
+		// CHAT-303: the per-message delete and the room-level cutoff stack. Either one
+		// alone is enough to hide a message.
+		{"deleted for this viewer and before the cutoff", msg(DeletedByReceiver, tEarly), receiver, ptr(tBase), false},
+
+		// Unsent rows stay in the list so the placeholder can be rendered.
+		{"unsent stays visible in the message list", msg(Unsent, tLate), receiver, ptr(tBase), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsMessageVisibleFor(c.msg, c.viewerID, c.clearedAt); got != c.want {
+				t.Errorf("IsMessageVisibleFor() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsLastMessageVisibleFor(t *testing.T) {
+	const sender, receiver = "user-a", "user-b"
+
+	msg := func(status MessageStatus, createdAt time.Time) *Message {
+		return &Message{SenderID: sender, Status: status, CreatedAt: createdAt}
+	}
+
+	cases := []struct {
+		name      string
+		msg       *Message
+		clearedAt *time.Time
+		want      bool
+	}{
+		{"normal message", msg(Normal, tLate), ptr(tBase), true},
+		// The only difference from IsMessageVisibleFor: an unsent message has nothing
+		// to preview, so the chat list falls back to the next candidate.
+		{"unsent has no preview", msg(Unsent, tLate), ptr(tBase), false},
+		{"before the cutoff", msg(Normal, tEarly), ptr(tBase), false},
+		{"deleted for this viewer", msg(DeletedByReceiver, tLate), ptr(tBase), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsLastMessageVisibleFor(c.msg, receiver, c.clearedAt); got != c.want {
+				t.Errorf("IsLastMessageVisibleFor() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/service/chat.go
+++ b/service/chat.go
@@ -482,6 +482,28 @@ func (s *chatService) SendMessage(ctx context.Context, bundleID, userID, chatID 
 	return msg, nil
 }
 
+// Archive hides a chat room from this user's list, or brings it back.
+//
+// This is a different axis from the chat_thread.status annotation: the todo/done marks
+// survive archiving, and the legacy Deleted mark keeps its own "hidden forever"
+// meaning. See docs/chat_visibility.md for why the two are not merged.
+func (s *chatService) Archive(ctx context.Context, bundleID, userID, chatID string, archived bool) error {
+	app, err := s.a.GetByBundleID(ctx, bundleID)
+	if err != nil {
+		logging.Errorw(ctx, "failed to get app by bundle ID", "err", err, "bundleID", bundleID)
+		return err
+	}
+
+	// Get returns an error unless this user owns a chat_thread row for the room, which
+	// is the membership check every other method in this service relies on.
+	if _, err := s.c.Get(ctx, app.ID, chatID, userID); err != nil {
+		logging.Errorw(ctx, "get chat failed", "err", err, "user_id", userID, "chat_id", chatID)
+		return err
+	}
+
+	return s.c.SetHidden(ctx, chatID, userID, archived)
+}
+
 func (s *chatService) UnsendMessage(ctx context.Context, bundleID, userID, messageID string) error {
 
 	app, err := s.a.GetByBundleID(ctx, bundleID)

--- a/service/chat_fakes_test.go
+++ b/service/chat_fakes_test.go
@@ -1,0 +1,373 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/A-pen-app/hire-sdk/models"
+	"github.com/A-pen-app/hire-sdk/store"
+)
+
+// In-memory fakes for the chat archive / delete suite (see chat_test.go).
+//
+// Only the behaviour those scenarios depend on is modelled. Each fake embeds its
+// store interface, so any method this file does not implement still satisfies the
+// compiler but nil-panics the moment a test reaches it — which is the signal you
+// want: it means the test is exercising a path the fake was never meant to cover.
+//
+// Where the fake deliberately diverges from store/chat.go, the difference is called
+// out inline. The important shared property is the one the whole feature rests on:
+// chat_thread is per-user, so every read and write here is keyed by
+// (chatID, ownerID) and touching one participant's row never changes the other's.
+//
+// This file is the hire-sdk twin of megaphone's service/chat_fakes_test.go. The two
+// diverge only where the schemas do — hire-sdk rooms carry app_id, post_id and
+// is_pinned, and every service method resolves a bundle ID to an app first.
+
+const testBundleID = "com.test.hire"
+const testAppID = "app-1"
+
+// ---------------------------------------------------------------------------
+// chat store
+// ---------------------------------------------------------------------------
+
+// fakeThread mirrors one public.chat_thread row.
+type fakeThread struct {
+	chatID      string
+	senderID    string // the owner of this row
+	receiverID  string // the counterparty
+	unreadCount int64
+	lastSeenAt  *time.Time
+	status      models.ChatAnnotation
+	controlFlag models.ChatControlFlag
+	isPinned    bool
+	hiddenAt    *time.Time
+	clearedAt   *time.Time
+}
+
+// fakeChat mirrors one public.chat row — the state both participants share.
+type fakeChat struct {
+	id            string
+	appID         string
+	updatedAt     time.Time
+	createdAt     time.Time
+	lastMessageID *string
+	postID        *string
+}
+
+type fakeChatStore struct {
+	store.Chat
+
+	mu       sync.Mutex
+	chats    map[string]*fakeChat
+	threads  map[string]*fakeThread // chatID + "\x00" + ownerID
+	messages []*models.Message      // append-only, ordered oldest first
+	seq      int
+
+	// clock drives created_at / updated_at. Tests advance it explicitly so that
+	// "strictly later than" boundaries (CHAT-305 / CHAT-306) are reproducible rather
+	// than dependent on how fast the test runs.
+	now time.Time
+}
+
+func newFakeChatStore() *fakeChatStore {
+	return &fakeChatStore{
+		chats:   map[string]*fakeChat{},
+		threads: map[string]*fakeThread{},
+		now:     time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func threadKey(chatID, ownerID string) string { return chatID + "\x00" + ownerID }
+
+// seedRoom creates a room plus both chat_thread rows, the way GetChatID does.
+func (f *fakeChatStore) seedRoom(chatID, userA, userB string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.chats[chatID] = &fakeChat{id: chatID, appID: testAppID, updatedAt: f.now, createdAt: f.now}
+	f.threads[threadKey(chatID, userA)] = &fakeThread{chatID: chatID, senderID: userA, receiverID: userB}
+	f.threads[threadKey(chatID, userB)] = &fakeThread{chatID: chatID, senderID: userB, receiverID: userA}
+}
+
+func (f *fakeChatStore) Get(ctx context.Context, appID, chatID, userID string) (*models.ChatRoom, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.threads[threadKey(chatID, userID)]
+	if !ok {
+		// Matches the real store: a non-participant gets sql.ErrNoRows, which is what
+		// the service layer relies on as its membership check.
+		return nil, sql.ErrNoRows
+	}
+	if f.chats[chatID].appID != appID {
+		return nil, sql.ErrNoRows
+	}
+	return f.toChatRoom(t), nil
+}
+
+// toChatRoom builds the joined chat_thread + chat view the real SELECT returns.
+// Caller must hold the lock.
+func (f *fakeChatStore) toChatRoom(t *fakeThread) *models.ChatRoom {
+	c := f.chats[t.chatID]
+	return &models.ChatRoom{
+		ChatID:        t.chatID,
+		SenderID:      t.senderID,
+		ReceiverID:    t.receiverID,
+		AppID:         c.appID,
+		UnreadCount:   t.unreadCount,
+		LastSeenAt:    t.lastSeenAt,
+		Status:        t.status,
+		ControlFlag:   t.controlFlag,
+		IsPinned:      t.isPinned,
+		CreatedAt:     c.createdAt,
+		UpdatedAt:     c.updatedAt,
+		LastMessageID: c.lastMessageID,
+		PostID:        c.postID,
+		HiddenAt:      t.hiddenAt,
+		ClearedAt:     t.clearedAt,
+	}
+}
+
+func (f *fakeChatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, isOfficialRole bool) ([]*models.ChatRoom, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := []*models.ChatRoom{}
+	for _, t := range f.threads {
+		c := f.chats[t.chatID]
+		if t.senderID != userID || c.appID != appID {
+			continue
+		}
+		// Mirrors the real WHERE clause: rooms marked Deleted are excluded.
+		if t.status == models.Deleted {
+			continue
+		}
+		// Rule R1, mirroring
+		// (CT.hidden_at IS NULL OR C.updated_at > CT.hidden_at).
+		if models.IsChatHidden(t.hiddenAt, c.updatedAt) {
+			continue
+		}
+		if status != models.None && t.status != status {
+			continue
+		}
+		if unreadOnly && t.unreadCount == 0 {
+			continue
+		}
+		out = append(out, f.toChatRoom(t))
+	}
+	// ORDER BY CT.is_pinned DESC, C.updated_at DESC
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].IsPinned != out[j].IsPinned {
+			return out[i].IsPinned
+		}
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	if count > 0 && len(out) > count {
+		out = out[:count]
+	}
+	return out, nil
+}
+
+func (f *fakeChatStore) Pin(ctx context.Context, chatID, userID string, isPinned bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.threads[threadKey(chatID, userID)]
+	if !ok {
+		return sql.ErrNoRows
+	}
+	t.isPinned = isPinned
+	return nil
+}
+
+func (f *fakeChatStore) Annotate(ctx context.Context, chatID, userID string, status models.ChatAnnotation) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.threads[threadKey(chatID, userID)]
+	if !ok {
+		return sql.ErrNoRows
+	}
+	t.status = status
+	return nil
+}
+
+func (f *fakeChatStore) SetHidden(ctx context.Context, chatID, userID string, hidden bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.threads[threadKey(chatID, userID)]
+	if !ok {
+		return sql.ErrNoRows
+	}
+	if !hidden {
+		t.hiddenAt = nil
+		return nil
+	}
+	at := f.now
+	t.hiddenAt = &at
+	// Rule R3: archiving marks the room read.
+	t.unreadCount = 0
+	return nil
+}
+
+func (f *fakeChatStore) Read(ctx context.Context, userID, chatID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if t, ok := f.threads[threadKey(chatID, userID)]; ok {
+		t.unreadCount = 0
+	}
+	return nil
+}
+
+func (f *fakeChatStore) GetMessage(ctx context.Context, messageID string) (*models.Message, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, m := range f.messages {
+		if m.ID == messageID {
+			cp := *m
+			return &cp, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (f *fakeChatStore) GetMessages(ctx context.Context, chatID string, next string, count int) ([]*models.Message, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Newest first, matching ORDER BY created_at DESC.
+	out := []*models.Message{}
+	for i := len(f.messages) - 1; i >= 0; i-- {
+		if f.messages[i].ChatID != chatID {
+			continue
+		}
+		cp := *f.messages[i]
+		out = append(out, &cp)
+		if count > 0 && len(out) == count {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeChatStore) GetNewMessages(ctx context.Context, chatID string, after time.Time) ([]*models.Message, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := []*models.Message{}
+	for _, m := range f.messages {
+		if m.ChatID == chatID && m.CreatedAt.After(after) {
+			cp := *m
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeChatStore) AddMessage(ctx context.Context, userID, chatID, receiverID string, typ models.MessageType, body *string, mediaIDs []string, replyToMessageID, referenceID *string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.seq++
+	f.now = f.now.Add(time.Minute)
+	id := "msg-" + itoa(f.seq)
+	f.messages = append(f.messages, &models.Message{
+		ID:               id,
+		ChatID:           chatID,
+		SenderID:         userID,
+		CreatedAt:        f.now,
+		Status:           models.Normal,
+		Type:             typ,
+		Body:             body,
+		MediaIDs:         mediaIDs,
+		ReplyToMessageID: replyToMessageID,
+		RefID:            referenceID,
+	})
+
+	// The shared chat row moves forward. This is the column R1 compares against, so it
+	// is what makes a new message un-archive a room.
+	if c, ok := f.chats[chatID]; ok {
+		c.updatedAt = f.now
+		c.lastMessageID = &id
+	}
+	// The receiver's unread count goes up and NeverGotMessages is cleared.
+	if t, ok := f.threads[threadKey(chatID, receiverID)]; ok {
+		t.unreadCount++
+		t.controlFlag &^= models.NeverGotMessages
+	}
+	return id, nil
+}
+
+func (f *fakeChatStore) EditMessage(ctx context.Context, messageID string, newStatus models.MessageStatus) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, m := range f.messages {
+		if m.ID == messageID {
+			// The real store ORs the flag in rather than replacing it, so a message can
+			// be deleted by both sides independently.
+			m.Status |= newStatus
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+// itoa keeps the fake dependency-free; strconv would do but this reads better in IDs.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// the other five stores
+// ---------------------------------------------------------------------------
+
+// fakeAppStore resolves the one bundle ID these tests use. Every service method starts
+// here, so it is the only one of the five that must actually work.
+type fakeAppStore struct {
+	store.App
+}
+
+func (f *fakeAppStore) GetByBundleID(ctx context.Context, bundleID string) (*models.App, error) {
+	if bundleID != testBundleID {
+		return nil, sql.ErrNoRows
+	}
+	return &models.App{ID: testAppID, BundleID: bundleID}, nil
+}
+
+// The remaining stores are only reached by the enrichment paths (resume snapshots,
+// business cards, media, subscriptions) that the archive / delete scenarios stay out
+// of. They return empty results rather than nil-panicking so that GetChats can walk
+// its batch-enrichment steps without a real hiring database.
+type fakeResumeStore struct{ store.Resume }
+
+func (f *fakeResumeStore) ListRelations(ctx context.Context, appID string, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, error) {
+	return nil, nil
+}
+
+type fakeBusinessCardStore struct{ store.BusinessCard }
+
+func (f *fakeBusinessCardStore) GetSnapshotOwners(ctx context.Context, snapshotIDs []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+type fakeSubscriptionStore struct{ store.Subscription }
+
+func (f *fakeSubscriptionStore) Get(ctx context.Context, appID, userID string) (*models.UserSubscription, error) {
+	return nil, sql.ErrNoRows
+}
+
+type fakeMediaStore struct{ store.Media }
+
+// ---------------------------------------------------------------------------
+// wiring
+// ---------------------------------------------------------------------------
+
+func newChatSvcForTest(c *fakeChatStore) Chat {
+	return NewChat(c, &fakeResumeStore{}, &fakeAppStore{}, &fakeMediaStore{}, &fakeSubscriptionStore{}, &fakeBusinessCardStore{})
+}

--- a/service/chat_test.go
+++ b/service/chat_test.go
@@ -1,0 +1,419 @@
+package service
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/A-pen-app/hire-sdk/models"
+	"github.com/A-pen-app/logging"
+)
+
+// TestMain initialises the logger. Several chat service methods call logging.Errorw
+// on their error paths, and logging's package-level zap.Logger stays nil until
+// Initialize runs, so any test that exercises a failure (membership rejection, for
+// one) would nil-panic instead of returning its error.
+//
+// logging is already a non-test dependency of this module, so this adds nothing to
+// go.mod — the suite stays standard-library-only for assertions.
+func TestMain(m *testing.M) {
+	if err := logging.Initialize(nil); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+// Acceptance scenarios for chat room archive and delete.
+//
+// These mirror the scenario matrix in docs/chat_visibility.md one-for-one, and the
+// CHAT-xxx IDs point at the shared test case page. The same matrix is implemented in
+// megaphone and in the apen/nurse/phar API repos; those files are this one's
+// consistency baseline, so a change here needs the same change there.
+//
+// Scenarios whose feature has not landed yet are marked t.Skip with the stage that
+// will turn them on. Turning a skip into a passing test *is* the acceptance criterion
+// for that stage — do not delete a skipped case to make a run green.
+
+const (
+	userA = "user-a"
+	userB = "user-b"
+	room  = "chat-1"
+)
+
+// setupRoom seeds one room shared by A and B, plus n messages alternating B, A, B, …
+// so both participants have sent something. Returns the wired service.
+func setupRoom(t *testing.T, n int) (Chat, *fakeChatStore) {
+	t.Helper()
+	c := newFakeChatStore()
+	c.seedRoom(room, userA, userB)
+	svc := newChatSvcForTest(c)
+
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		sender, receiver := userB, userA
+		if i%2 == 1 {
+			sender, receiver = userA, userB
+		}
+		if _, err := c.AddMessage(ctx, sender, room, receiver, models.MsgText, textPtr("m"+itoa(i+1)), nil, nil, nil); err != nil {
+			t.Fatalf("seed message %d: %v", i+1, err)
+		}
+	}
+	return svc, c
+}
+
+func textPtr(s string) *string { return &s }
+
+// unreadOf reads the per-room unread count straight off the fake's chat_thread row,
+// which is what rule R3 talks about.
+func unreadOf(t *testing.T, c *fakeChatStore, userID string) int64 {
+	t.Helper()
+	th, err := c.Get(context.Background(), testAppID, room, userID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", userID, err)
+	}
+	return th.UnreadCount
+}
+
+// visibleMessages is the assertion the whole feature turns on: how many messages the
+// service hands this particular viewer.
+func visibleMessages(t *testing.T, svc Chat, userID string) int {
+	t.Helper()
+	msgs, _, err := svc.GetChatMessages(context.Background(), testBundleID, userID, room, "", 100)
+	if err != nil {
+		t.Fatalf("GetChatMessages(%s): %v", userID, err)
+	}
+	return len(msgs)
+}
+
+// listedRooms reports how many rooms the viewer's chat list contains.
+func listedRooms(t *testing.T, svc Chat, userID string) int {
+	t.Helper()
+	chats, _, err := svc.GetChats(context.Background(), testBundleID, userID, "", 100)
+	if err != nil {
+		t.Fatalf("GetChats(%s): %v", userID, err)
+	}
+	return len(chats)
+}
+
+// ---------------------------------------------------------------------------
+// Baseline — the harness itself
+// ---------------------------------------------------------------------------
+
+// Not one of the numbered scenarios: this pins down what "10 messages, both sides see
+// them" means before any archive or delete enters the picture. If this breaks, every
+// scenario below is measuring the wrong thing.
+func TestBaselineBothSidesSeeEveryMessage(t *testing.T) {
+	svc, _ := setupRoom(t, 10)
+
+	if got := visibleMessages(t, svc, userA); got != 10 {
+		t.Errorf("A sees %d messages, want 10", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 10 {
+		t.Errorf("B sees %d messages, want 10", got)
+	}
+	if got := listedRooms(t, svc, userA); got != 1 {
+		t.Errorf("A lists %d rooms, want 1", got)
+	}
+	if got := listedRooms(t, svc, userB); got != 1 {
+		t.Errorf("B lists %d rooms, want 1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 / 2 / 7 / 11 — archive (stage 1)
+// ---------------------------------------------------------------------------
+
+// CHAT-101 / CHAT-102
+func TestArchiveHidesRoomButKeepsMessages(t *testing.T) {
+	svc, _ := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	if got := listedRooms(t, svc, userA); got != 0 {
+		t.Errorf("A lists %d rooms after archiving, want 0", got)
+	}
+	// CHAT-102: the room is only gone from the list. Opening it directly still shows
+	// everything, which is what separates archive from delete.
+	if got := visibleMessages(t, svc, userA); got != 10 {
+		t.Errorf("A sees %d messages inside an archived room, want 10", got)
+	}
+}
+
+// CHAT-103
+func TestArchiveDoesNotAffectTheOtherParty(t *testing.T) {
+	svc, _ := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	if got := listedRooms(t, svc, userB); got != 1 {
+		t.Errorf("B lists %d rooms, want 1 — archive is one-sided", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 10 {
+		t.Errorf("B sees %d messages, want 10", got)
+	}
+}
+
+// CHAT-104
+//
+// This is the scenario the whole design turns on: A archives, B sends the 11th
+// message, and both sides end up seeing all 11.
+func TestNewMessageRestoresAnArchivedRoomWithFullHistory(t *testing.T) {
+	svc, c := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if got := listedRooms(t, svc, userA); got != 0 {
+		t.Fatalf("precondition: A lists %d rooms after archiving, want 0", got)
+	}
+
+	if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m11"), nil, nil, nil); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	if got := listedRooms(t, svc, userA); got != 1 {
+		t.Errorf("A lists %d rooms after a new message, want 1", got)
+	}
+	if got := visibleMessages(t, svc, userA); got != 11 {
+		t.Errorf("A sees %d messages, want 11", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 11 {
+		t.Errorf("B sees %d messages, want 11", got)
+	}
+}
+
+// CHAT-105
+func TestOwnMessageRestoresAnArchivedRoom(t *testing.T) {
+	svc, c := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	// A sends into the room they archived themselves.
+	if _, err := c.AddMessage(ctx, userA, room, userB, models.MsgText, textPtr("m11"), nil, nil, nil); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	if got := listedRooms(t, svc, userA); got != 1 {
+		t.Errorf("A lists %d rooms after sending into an archived room, want 1", got)
+	}
+	if got := visibleMessages(t, svc, userA); got != 11 {
+		t.Errorf("A sees %d messages, want 11", got)
+	}
+}
+
+// CHAT-106
+//
+// Rule R3. Without this the badge would keep counting a room the user can no longer
+// open, so it could never be cleared.
+func TestArchiveMarksTheRoomAsRead(t *testing.T) {
+	svc, c := setupRoom(t, 0)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m"), nil, nil, nil); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+	}
+	if got := unreadOf(t, c, userA); got != 3 {
+		t.Fatalf("precondition: A has %d unread, want 3", got)
+	}
+
+	if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	if got := unreadOf(t, c, userA); got != 0 {
+		t.Errorf("A has %d unread after archiving, want 0", got)
+	}
+	if got := unreadOf(t, c, userB); got != 0 {
+		t.Errorf("B has %d unread, want 0 — A archiving must not touch B", got)
+	}
+}
+
+// CHAT-107
+func TestArchivedRoomIsExcludedFromEveryListQuery(t *testing.T) {
+	svc, c := setupRoom(t, 0)
+	ctx := context.Background()
+
+	// Give the room an unread message so the unread-only filter would otherwise
+	// return it, then archive.
+	if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m1"), nil, nil, nil); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts []models.GetOptionFunc
+	}{
+		{"default list", nil},
+		{"unread only", []models.GetOptionFunc{models.ByStatus(models.None, true)}},
+		{"marked todo", []models.GetOptionFunc{models.ByStatus(models.Todo, false)}},
+		{"marked done", []models.GetOptionFunc{models.ByStatus(models.Done, false)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			chats, _, err := svc.GetChats(ctx, testBundleID, userA, "", 100, tc.opts...)
+			if err != nil {
+				t.Fatalf("GetChats: %v", err)
+			}
+			if len(chats) != 0 {
+				t.Errorf("archived room appeared in %q (%d rooms)", tc.name, len(chats))
+			}
+		})
+	}
+}
+
+// CHAT-108
+func TestArchivingTwiceIsIdempotent(t *testing.T) {
+	svc, _ := setupRoom(t, 10)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+			t.Fatalf("Archive #%d: %v", i+1, err)
+		}
+	}
+
+	if got := listedRooms(t, svc, userA); got != 0 {
+		t.Errorf("A lists %d rooms, want 0", got)
+	}
+	if got := visibleMessages(t, svc, userA); got != 10 {
+		t.Errorf("A sees %d messages, want 10 — archiving never touches messages", got)
+	}
+}
+
+// CHAT-109
+func TestArchiveRequiresMembership(t *testing.T) {
+	svc, _ := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Archive(ctx, testBundleID, "user-c", room, true); err == nil {
+		t.Fatal("Archive by a non-participant succeeded, want an error")
+	}
+
+	// Neither participant's view may have changed.
+	if got := listedRooms(t, svc, userA); got != 1 {
+		t.Errorf("A lists %d rooms, want 1", got)
+	}
+	if got := listedRooms(t, svc, userB); got != 1 {
+		t.Errorf("B lists %d rooms, want 1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 / 4 / 5 / 6 / 8 — delete (stage 2)
+// ---------------------------------------------------------------------------
+
+// CHAT-201 / CHAT-202
+func TestDeleteClearsMySideAndLeavesTheirs(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// CHAT-203
+func TestNewMessageAfterDeleteShowsOnlyPostCutoffMessages(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// CHAT-204
+func TestMyOwnMessageAfterDeleteIsVisibleToMe(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// CHAT-205
+func TestDeleteCutoffIsNeverReset(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// CHAT-206
+func TestDeleteMarksTheRoomAsRead(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// CHAT-207
+func TestLastMessagePreviewRespectsTheCutoff(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// CHAT-208
+func TestDeletingTwiceMovesTheCutoffForward(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// CHAT-209
+func TestDeleteRequiresMembership(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// CHAT-301 / CHAT-302
+func TestArchiveAndDeleteInteract(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 9 / 9b — the per-message delete, which already exists
+// ---------------------------------------------------------------------------
+
+// CHAT-311: a message the viewer deleted is dropped entirely. No "unsent" placeholder
+// is left in its place — that would read as the other party having unsent it.
+func TestPerMessageDeleteRemovesTheRowEntirely(t *testing.T) {
+	// hire-sdk has no per-message delete writer at all: the read side is fully
+	// implemented in aggregateMessages, but nothing ever sets DeletedBySender or
+	// DeletedByReceiver (gap G4 in docs/chat_visibility.md). megaphone is where this
+	// scenario runs today.
+	t.Skip("hire-sdk has no per-message delete writer (G4)")
+}
+
+// CHAT-311, the other direction: the sender deleting their own message hides it from
+// the sender only.
+func TestPerMessageDeleteBySenderHidesItFromTheSenderOnly(t *testing.T) {
+	// hire-sdk has no per-message delete writer at all: the read side is fully
+	// implemented in aggregateMessages, but nothing ever sets DeletedBySender or
+	// DeletedByReceiver (gap G4 in docs/chat_visibility.md). megaphone is where this
+	// scenario runs today.
+	t.Skip("hire-sdk has no per-message delete writer (G4)")
+}
+
+// CHAT-304: unsend is a different thing from a per-message delete — the row stays and
+// both sides see the placeholder.
+func TestUnsendKeepsTheRowForBothSides(t *testing.T) {
+	svc, c := setupRoom(t, 3)
+	ctx := context.Background()
+
+	target := c.messages[1] // sent by A, so A is allowed to unsend it
+	if err := svc.UnsendMessage(ctx, testBundleID, userA, target.ID); err != nil {
+		t.Fatalf("UnsendMessage: %v", err)
+	}
+
+	if got := visibleMessages(t, svc, userA); got != 3 {
+		t.Errorf("A sees %d messages after an unsend, want 3 — the placeholder row stays", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 3 {
+		t.Errorf("B sees %d messages after an unsend, want 3 — the placeholder row stays", got)
+	}
+}
+
+// CHAT-303: the per-message delete and the room-level cutoff stack.
+func TestPerMessageDeleteStacksWithTheRoomCutoff(t *testing.T) {
+	t.Skip("stage 2: delete not implemented yet")
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 12 — megaphone only
+// ---------------------------------------------------------------------------
+
+// CHAT-401 and CHAT-402 are megaphone-only: the ChatAnnotation marks are reachable
+// there through PATCH /chats/:chat_id/mark. In hire-sdk, Annotate is not on the
+// service interface and has no route (gap G2 in docs/chat_visibility.md), so there is
+// nothing to assert here.
+

--- a/service/service.go
+++ b/service/service.go
@@ -23,6 +23,11 @@ type Chat interface {
 	FetchNewMessages(ctx context.Context, bundleID, userID, chatID string, lastMessageID string) ([]*models.Message, error)
 	SendMessage(ctx context.Context, bundleID, userID, chatID string, options ...models.SendOptionFunc) (*models.Message, error)
 	UnsendMessage(ctx context.Context, bundleID, userID, messageID string) error
+	// Archive hides a chat room from this user's list without touching any message.
+	// A new message from either side brings it back automatically, with the full
+	// history intact. Archiving also marks the room read. See docs/chat_visibility.md.
+	Archive(ctx context.Context, bundleID, userID, chatID string, archived bool) error
+
 	GetBusinessCardOnly(ctx context.Context, bundleID string, before time.Duration) ([]*models.BusinessCardChat, error)
 }
 

--- a/store/chat.go
+++ b/store/chat.go
@@ -42,12 +42,17 @@ func (s *chatStore) Get(ctx context.Context, appID, chatID, userID string) (*mod
 		CT.is_pinned,
 		C.business_card_snapshot_id,
 		C.access_status,
-		CT.hire_contact
+		CT.hire_contact,
+		CT.hidden_at,
+		CT.cleared_at
 	FROM public.chat_thread AS CT
 	JOIN public.chat AS C
 	ON CT.chat_id=C.id
 	WHERE C.id=? AND C.app_id=? AND CT.sender_id=?
 	`
+	// Note there is deliberately no hidden_at filter here. Archiving only removes a
+	// room from the list; opening it by direct link or from a notification must still
+	// work and must still show every message (CHAT-102).
 	values := []interface{}{
 		chatID,
 		appID,
@@ -121,6 +126,30 @@ func (s *chatStore) Annotate(ctx context.Context, chatID, userID string, status 
 	return nil
 }
 
+// SetHidden archives or un-archives a chat room for one user (rule R1).
+//
+// Archiving also drops the room's unread count to zero (rule R3): the room leaves the
+// list and there is no archived tab to open it from, so a surviving unread badge could
+// never be cleared.
+//
+// Un-archiving only clears the flag. It does not restore an unread count, because the
+// messages that produced it have been marked read.
+func (s *chatStore) SetHidden(ctx context.Context, chatID, userID string, hidden bool) error {
+	query := `
+	UPDATE public.chat_thread
+	SET hidden_at=CASE WHEN ? THEN now() ELSE NULL END,
+		unread_count=CASE WHEN ? THEN 0 ELSE unread_count END
+	WHERE chat_id=? AND sender_id=?
+	`
+	query = s.db.Rebind(query)
+	if _, err := s.db.Exec(query, hidden, hidden, chatID, userID); err != nil {
+		logging.Errorw(ctx, "set chat thread hidden failed", "err", err, "chatID", chatID, "userID", userID, "hidden", hidden)
+		return err
+	}
+
+	return nil
+}
+
 func (s *chatStore) Pin(ctx context.Context, chatID, userID string, isPinned bool) error {
 	query := `
 	UPDATE public.chat_thread
@@ -159,7 +188,9 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 		CT.is_pinned,
 		C.business_card_snapshot_id,
 		C.access_status,
-		CT.hire_contact
+		CT.hire_contact,
+		CT.hidden_at,
+		CT.cleared_at
 	FROM public.chat_thread AS CT
 	JOIN public.chat AS C
 	ON CT.chat_id=C.id
@@ -169,6 +200,12 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 		"CT.sender_id=?",
 		"C.updated_at<TO_TIMESTAMP(?)",
 		"CT.status!=?",
+		// Rule R1: an archived room stays out of the list until an activity strictly
+		// later than hidden_at. C.updated_at only moves when a message is added
+		// (AddMessage / AddMessages — every other UPDATE public.chat sets a single
+		// unrelated column), so a new message from either side restores the room with
+		// no extra write on the send path. See docs/chat_visibility.md.
+		"(CT.hidden_at IS NULL OR C.updated_at>CT.hidden_at)",
 	}
 	values := []interface{}{
 		appID,

--- a/store/store.go
+++ b/store/store.go
@@ -38,6 +38,7 @@ type Chat interface {
 	EditMessage(ctx context.Context, messageID string, newStatus models.MessageStatus) error
 	Annotate(ctx context.Context, chatID, userID string, status models.ChatAnnotation) error
 	Pin(ctx context.Context, chatID, userID string, isPinned bool) error
+	SetHidden(ctx context.Context, chatID, userID string, hidden bool) error
 	UpdateHireContact(ctx context.Context, chatID string, userID string, contact *models.HireContact) error
 	UpdateBusinessCardSnapshotID(ctx context.Context, chatID, snapshotID string) error
 	UpdateAccessStatus(ctx context.Context, chatID string, status models.AccessStatus) error


### PR DESCRIPTION
> **Stacked on #16** (the spec). Base is `docs/chat-visibility-spec`, so this diff shows only the implementation. Merge #16 first and this retargets to `main` cleanly.

## What this does

Archiving hides a chat room from one user's list without touching any message, and marks it read. A new message from either side brings it back automatically, with the full history intact. One-sided: the other participant is unaffected and is not notified.

```go
Archive(ctx, bundleID, userID, chatID, archived) error
```

**No HTTP routes here — this is a library.** The `PATCH /hire/chats/{id}/archive` routes land in the three API repos once this is tagged.

Deleting a room is the next stage; `cleared_at` ships in the same migration but nothing writes it yet.

## The design decision worth reviewing

**Restore-on-new-message costs nothing on the send path.** `chat.updated_at` only moves in `AddMessage` / `AddMessages` — every other `UPDATE public.chat` sets a single unrelated column — so the list query can just ask:

```sql
(CT.hidden_at IS NULL OR C.updated_at > CT.hidden_at)
```

No flag to clear, no extra write when a message arrives. (The three API repos cannot do this: their `chat_thread.updated_at` is also written by `DeleteMessage`, so a user deleting one of their own messages would resurrect a room they archived. They reset the flag explicitly instead.)

## Why not reuse `chat_thread.status`

It already has a `Deleted` value that `GetChats` filters on, so it looks like a ready-made flag. It isn't:

1. It is a **single-valued enum** — "archived" would become mutually exclusive with the todo/done marks
2. It **cannot express "restore on the next message"** — `AddMessage` only clears the `NeverGotMessages` control-flag bit, it never touches `status`
3. **In this SDK it is unreachable anyway** — `Annotate` is not on the `service.Chat` interface, has zero callers monorepo-wide, and has no route (gap G2 in the spec)

The existing `status != Deleted` condition is left exactly as it was.

## One thing that is deliberate, not an oversight

`Get` (single-room lookup) has **no** `hidden_at` filter. Archiving only removes a room from the list — opening it by direct link or from a notification has to keep working and keep showing every message. The spec's gap G1 was reworded on the base branch to say so, since it previously read as "close this".

## Migrations

New `migrations/` directory with its own README — this repo tracked no DDL at all before. The hiring DB is shared by apen / nurse / phar through `chat.app_id`, so the file is applied **once** and covers all three apps. It is deliberately not filed under an API repo's `migrations/`: those cover each app's own main database, and a row there would point at a file living in a different repo.

**There is no migration runner.** Order matters:

1. Apply the SQL to the hiring database
2. Merge and tag this repo
3. Bump `go.mod` in `apen-api`, `nurse-api` and `phar-api` — **all three together**, or older code keeps running older logic against the same database

## Tests

`go test ./...`. Standard library only — this repo deliberately carries no test dependencies, and that has not changed.

- `models/chat_visibility_test.go` — the visibility predicates, including the strict-inequality boundaries. **Byte-identical to megaphone's copy**, which is the point: the two are each other's consistency baseline
- `service/chat_test.go` — the scenario matrix from the spec, against a hand-written in-memory fake store

**10 pass, 12 skip.** The skips are the delete scenarios plus the two per-message-delete scenarios this SDK cannot run: the read side is fully implemented in `aggregateMessages`, but nothing ever writes `DeletedBySender` / `DeletedByReceiver` (gap G4). megaphone is where those two run today.

The fakes embed their store interface, so any method they do not implement nil-panics rather than silently returning a zero value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)