### PR TITLE
feat(chat): delete a chat room

### DIFF
--- a/service/chat.go
+++ b/service/chat.go
@@ -163,7 +163,7 @@ func (s *chatService) Get(ctx context.Context, bundleID, chatID, userID string) 
 	chat.HireStatus = &hireStatus
 
 	if msgID := chat.LastMessageID; msgID != nil {
-		msg, err := s.aggregateLastMessage(ctx, userID, *msgID, false)
+		msg, err := s.aggregateLastMessage(ctx, userID, *msgID, chat.ClearedAt, false)
 		if err != nil {
 			logging.Errorw(ctx, "aggregate last message failed", "err", err, "msgID", *msgID)
 		} else {
@@ -316,7 +316,7 @@ func (s *chatService) GetChats(ctx context.Context, bundleID, userID string, nex
 		chats[i].HireStatus = &hireStatus
 
 		if msgID := chats[i].LastMessageID; msgID != nil {
-			msg, err := s.aggregateLastMessage(ctx, userID, *msgID, true)
+			msg, err := s.aggregateLastMessage(ctx, userID, *msgID, chats[i].ClearedAt, true)
 			if err != nil {
 				logging.Errorw(ctx, "aggregate last message failed", "err", err, "msgID", *msgID)
 			} else {
@@ -384,8 +384,10 @@ func (s *chatService) FetchNewMessages(ctx context.Context, bundleID, userID, ch
 		return nil, err
 	}
 
-	// check ownership
-	if _, err := s.c.Get(ctx, app.ID, chatID, userID); err != nil {
+	// check ownership. The row we get back also carries this user's delete cutoff, so
+	// applying rule R2 costs no extra query.
+	chat, err := s.c.Get(ctx, app.ID, chatID, userID)
+	if err != nil {
 		logging.Errorw(ctx, "failed to verify chat ownership", "err", err, "appID", app.ID, "chatID", chatID, "userID", userID)
 		return nil, err
 	}
@@ -397,7 +399,7 @@ func (s *chatService) FetchNewMessages(ctx context.Context, bundleID, userID, ch
 		return nil, models.ErrorNotAllowed
 	}
 
-	nonFilteredMsgs, err := s.c.GetNewMessages(ctx, chatID, lastMsg.CreatedAt)
+	nonFilteredMsgs, err := s.c.GetNewMessages(ctx, chatID, lastMsg.CreatedAt, chat.ClearedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -413,8 +415,10 @@ func (s *chatService) GetChatMessages(ctx context.Context, bundleID, userID, cha
 		return nil, "", err
 	}
 
-	// check ownership
-	if _, err := s.c.Get(ctx, app.ID, chatID, userID); err != nil {
+	// check ownership. The row we get back also carries this user's delete cutoff, so
+	// applying rule R2 costs no extra query.
+	chat, err := s.c.Get(ctx, app.ID, chatID, userID)
+	if err != nil {
 		logging.Errorw(ctx, "failed to verify chat ownership", "err", err, "appID", app.ID, "chatID", chatID, "userID", userID)
 		return nil, "", err
 	}
@@ -423,7 +427,7 @@ func (s *chatService) GetChatMessages(ctx context.Context, bundleID, userID, cha
 	}
 
 	// get one more element for determining next cursor
-	nonFilteredMsgs, err := s.c.GetMessages(ctx, chatID, next, count+1)
+	nonFilteredMsgs, err := s.c.GetMessages(ctx, chatID, next, count+1, chat.ClearedAt)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get messages", "err", err, "chatID", chatID, "count", count+1)
 		return nil, "", err
@@ -502,6 +506,27 @@ func (s *chatService) Archive(ctx context.Context, bundleID, userID, chatID stri
 	}
 
 	return s.c.SetHidden(ctx, chatID, userID, archived)
+}
+
+// Clear deletes a chat room for this user: everything up to now stops being visible to
+// them, and the room leaves their list.
+//
+// One-sided and not recoverable. The other participant keeps the full history, and no
+// message row is touched — this only moves the caller's own cutoff. Messages sent after
+// the cutoff arrive and display normally. See docs/chat_visibility.md.
+func (s *chatService) Clear(ctx context.Context, bundleID, userID, chatID string) error {
+	app, err := s.a.GetByBundleID(ctx, bundleID)
+	if err != nil {
+		logging.Errorw(ctx, "failed to get app by bundle ID", "err", err, "bundleID", bundleID)
+		return err
+	}
+
+	if _, err := s.c.Get(ctx, app.ID, chatID, userID); err != nil {
+		logging.Errorw(ctx, "get chat failed", "err", err, "user_id", userID, "chat_id", chatID)
+		return err
+	}
+
+	return s.c.SetCleared(ctx, chatID, userID)
 }
 
 func (s *chatService) UnsendMessage(ctx context.Context, bundleID, userID, messageID string) error {
@@ -611,22 +636,20 @@ func toResumeStatus(status models.AccessStatus) models.ResumeStatus {
 }
 
 // aggregateLastMessage processes the last message with business logic (without user info)
-func (s *chatService) aggregateLastMessage(ctx context.Context, userID string, msgID string, isInjectContent bool) (*models.Message, error) {
+func (s *chatService) aggregateLastMessage(ctx context.Context, userID string, msgID string, clearedAt *time.Time, isInjectContent bool) (*models.Message, error) {
 	msg, err := s.c.GetMessage(ctx, msgID)
 	if err != nil {
 		logging.Errorw(ctx, "get last message failed", "err", err, "msgID", msgID)
 		return nil, err
 	}
 
-	status := msg.Status
-	switch {
-	case status.HasOneOf(models.DeletedBySender) && userID == msg.SenderID,
-		status.HasOneOf(models.DeletedByReceiver) && userID != msg.SenderID,
-		status.HasOneOf(models.Unsent):
+	// Rules R2 and R4: skip a preview this user deleted, unsent, or that falls before
+	// their delete cutoff. Returning nil leaves ChatRoom.LastMessage unset and the
+	// client falls back to its empty-preview rendering.
+	if !models.IsLastMessageVisibleFor(msg, userID, clearedAt) {
 		return nil, nil
-	default:
-		msg.Status = models.Normal
 	}
+	msg.Status = models.Normal
 
 	if isInjectContent {
 		if err := s.injectContent(ctx, userID, msg, false); err != nil {
@@ -709,12 +732,13 @@ func (s *chatService) aggregateMessages(ctx context.Context, userID string, nonF
 	msgs := []*models.Message{}
 	for i := range nonFilteredMsgs {
 		msg := nonFilteredMsgs[i]
+		// Rule R4: a message this user deleted is dropped entirely, leaving no
+		// placeholder — a placeholder would read as the other party having unsent it.
+		if models.IsMessageDeletedFor(msg.Status, msg.SenderID, userID) {
+			continue
+		}
 		status := msg.Status
 		switch {
-		case status.HasOneOf(models.DeletedBySender) && userID == msg.SenderID,
-			status.HasOneOf(models.DeletedByReceiver) && userID != msg.SenderID:
-			// user deleted this message, skip it
-			continue
 		case status.HasOneOf(models.Unsent):
 			// wipe out message content for unsent
 			msg.Body = nil

--- a/service/chat_fakes_test.go
+++ b/service/chat_fakes_test.go
@@ -210,6 +210,23 @@ func (f *fakeChatStore) SetHidden(ctx context.Context, chatID, userID string, hi
 	return nil
 }
 
+func (f *fakeChatStore) SetCleared(ctx context.Context, chatID, userID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.threads[threadKey(chatID, userID)]
+	if !ok {
+		return sql.ErrNoRows
+	}
+	at := f.now
+	// Delete stamps both: the cutoff hides the history, hidden_at takes the room out
+	// of the list. Calling it again just moves both forward.
+	t.clearedAt = &at
+	t.hiddenAt = &at
+	// Rule R3: deleting marks the room read.
+	t.unreadCount = 0
+	return nil
+}
+
 func (f *fakeChatStore) Read(ctx context.Context, userID, chatID string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -231,13 +248,17 @@ func (f *fakeChatStore) GetMessage(ctx context.Context, messageID string) (*mode
 	return nil, sql.ErrNoRows
 }
 
-func (f *fakeChatStore) GetMessages(ctx context.Context, chatID string, next string, count int) ([]*models.Message, error) {
+func (f *fakeChatStore) GetMessages(ctx context.Context, chatID string, next string, count int, clearedAt *time.Time) ([]*models.Message, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	// Newest first, matching ORDER BY created_at DESC.
 	out := []*models.Message{}
 	for i := len(f.messages) - 1; i >= 0; i-- {
 		if f.messages[i].ChatID != chatID {
+			continue
+		}
+		// Rule R2, mirroring the real query's AND created_at > ?
+		if !models.IsAfterCutoff(f.messages[i].CreatedAt, clearedAt) {
 			continue
 		}
 		cp := *f.messages[i]
@@ -249,12 +270,12 @@ func (f *fakeChatStore) GetMessages(ctx context.Context, chatID string, next str
 	return out, nil
 }
 
-func (f *fakeChatStore) GetNewMessages(ctx context.Context, chatID string, after time.Time) ([]*models.Message, error) {
+func (f *fakeChatStore) GetNewMessages(ctx context.Context, chatID string, after time.Time, clearedAt *time.Time) ([]*models.Message, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	out := []*models.Message{}
 	for _, m := range f.messages {
-		if m.ChatID == chatID && m.CreatedAt.After(after) {
+		if m.ChatID == chatID && m.CreatedAt.After(after) && models.IsAfterCutoff(m.CreatedAt, clearedAt) {
 			cp := *m
 			out = append(out, &cp)
 		}

--- a/service/chat_test.go
+++ b/service/chat_test.go
@@ -317,47 +317,238 @@ func TestArchiveRequiresMembership(t *testing.T) {
 
 // CHAT-201 / CHAT-202
 func TestDeleteClearsMySideAndLeavesTheirs(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	svc, _ := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+
+	if got := listedRooms(t, svc, userA); got != 0 {
+		t.Errorf("A lists %d rooms after deleting, want 0", got)
+	}
+	if got := visibleMessages(t, svc, userA); got != 0 {
+		t.Errorf("A sees %d messages after deleting, want 0", got)
+	}
+	// The other side is untouched — no message row was modified, only A's cutoff.
+	if got := listedRooms(t, svc, userB); got != 1 {
+		t.Errorf("B lists %d rooms, want 1", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 10 {
+		t.Errorf("B sees %d messages, want 10", got)
+	}
 }
 
 // CHAT-203
 func TestNewMessageAfterDeleteShowsOnlyPostCutoffMessages(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	svc, c := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m11"), nil, nil, nil); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	if got := listedRooms(t, svc, userA); got != 1 {
+		t.Errorf("A lists %d rooms after a new message, want 1", got)
+	}
+	if got := visibleMessages(t, svc, userA); got != 1 {
+		t.Errorf("A sees %d messages, want 1 — only the one sent after the cutoff", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 11 {
+		t.Errorf("B sees %d messages, want 11", got)
+	}
 }
 
 // CHAT-204
 func TestMyOwnMessageAfterDeleteIsVisibleToMe(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	svc, c := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, err := c.AddMessage(ctx, userA, room, userB, models.MsgText, textPtr("m11"), nil, nil, nil); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	if got := visibleMessages(t, svc, userA); got != 1 {
+		t.Errorf("A sees %d messages, want 1 — their own, sent after the cutoff", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 11 {
+		t.Errorf("B sees %d messages, want 11", got)
+	}
 }
 
 // CHAT-205
 func TestDeleteCutoffIsNeverReset(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	svc, c := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("after"), nil, nil, nil); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+	}
+
+	if got := visibleMessages(t, svc, userA); got != 3 {
+		t.Errorf("A sees %d messages, want exactly 3 — the original 10 must never come back", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 13 {
+		t.Errorf("B sees %d messages, want 13", got)
+	}
 }
 
 // CHAT-206
 func TestDeleteMarksTheRoomAsRead(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	svc, c := setupRoom(t, 0)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m"), nil, nil, nil); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+	}
+	if got := unreadOf(t, c, userA); got != 3 {
+		t.Fatalf("precondition: A has %d unread, want 3", got)
+	}
+
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+
+	if got := unreadOf(t, c, userA); got != 0 {
+		t.Errorf("A has %d unread after deleting, want 0", got)
+	}
+	if got := unreadOf(t, c, userB); got != 0 {
+		t.Errorf("B has %d unread, want 0 — A deleting must not touch B", got)
+	}
 }
 
 // CHAT-207
 func TestLastMessagePreviewRespectsTheCutoff(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	svc, c := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m11"), nil, nil, nil); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	chats, _, err := svc.GetChats(ctx, testBundleID, userA, "", 100)
+	if err != nil {
+		t.Fatalf("GetChats: %v", err)
+	}
+	if len(chats) != 1 {
+		t.Fatalf("A lists %d rooms, want 1", len(chats))
+	}
+	if chats[0].LastMessage == nil {
+		t.Fatal("A has no preview, want the message sent after the cutoff")
+	}
+	if got := *chats[0].LastMessage.Body; got != "m11" {
+		t.Errorf("preview is %q, want %q — never a message from before the cutoff", got, "m11")
+	}
 }
 
 // CHAT-208
 func TestDeletingTwiceMovesTheCutoffForward(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	svc, c := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear #1: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("after"), nil, nil, nil); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+	}
+	if got := visibleMessages(t, svc, userA); got != 2 {
+		t.Fatalf("precondition: A sees %d messages, want 2", got)
+	}
+
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear #2: %v", err)
+	}
+
+	if got := visibleMessages(t, svc, userA); got != 0 {
+		t.Errorf("A sees %d messages after a second delete, want 0", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 12 {
+		t.Errorf("B sees %d messages, want 12", got)
+	}
 }
 
 // CHAT-209
 func TestDeleteRequiresMembership(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	svc, _ := setupRoom(t, 10)
+	ctx := context.Background()
+
+	if err := svc.Clear(ctx, testBundleID, "user-c", room); err == nil {
+		t.Fatal("Clear by a non-participant succeeded, want an error")
+	}
+
+	if got := visibleMessages(t, svc, userA); got != 10 {
+		t.Errorf("A sees %d messages, want 10", got)
+	}
+	if got := visibleMessages(t, svc, userB); got != 10 {
+		t.Errorf("B sees %d messages, want 10", got)
+	}
 }
 
 // CHAT-301 / CHAT-302
 func TestArchiveAndDeleteInteract(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	ctx := context.Background()
+
+	t.Run("delete supersedes archive", func(t *testing.T) {
+		svc, _ := setupRoom(t, 10)
+		if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+			t.Fatalf("Archive: %v", err)
+		}
+		if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+			t.Fatalf("Clear: %v", err)
+		}
+		if got := listedRooms(t, svc, userA); got != 0 {
+			t.Errorf("A lists %d rooms, want 0", got)
+		}
+		if got := visibleMessages(t, svc, userA); got != 0 {
+			t.Errorf("A sees %d messages, want 0", got)
+		}
+	})
+
+	t.Run("archiving after a delete keeps the cutoff", func(t *testing.T) {
+		svc, c := setupRoom(t, 10)
+		if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+			t.Fatalf("Clear: %v", err)
+		}
+		if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m11"), nil, nil, nil); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+		if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
+			t.Fatalf("Archive: %v", err)
+		}
+		if got := listedRooms(t, svc, userA); got != 0 {
+			t.Fatalf("A lists %d rooms after archiving, want 0", got)
+		}
+
+		if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m12"), nil, nil, nil); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+		if got := listedRooms(t, svc, userA); got != 1 {
+			t.Errorf("A lists %d rooms, want 1", got)
+		}
+		// Two messages after the cutoff, never the original ten.
+		if got := visibleMessages(t, svc, userA); got != 2 {
+			t.Errorf("A sees %d messages, want 2", got)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -405,7 +596,10 @@ func TestUnsendKeepsTheRowForBothSides(t *testing.T) {
 
 // CHAT-303: the per-message delete and the room-level cutoff stack.
 func TestPerMessageDeleteStacksWithTheRoomCutoff(t *testing.T) {
-	t.Skip("stage 2: delete not implemented yet")
+	// The room-level cutoff works here, but there is nothing to stack it with: hire-sdk
+	// has no per-message delete writer at all (gap G4 in docs/chat_visibility.md).
+	// megaphone is where this scenario runs today.
+	t.Skip("hire-sdk has no per-message delete writer (G4)")
 }
 
 // ---------------------------------------------------------------------------

--- a/service/service.go
+++ b/service/service.go
@@ -28,6 +28,11 @@ type Chat interface {
 	// history intact. Archiving also marks the room read. See docs/chat_visibility.md.
 	Archive(ctx context.Context, bundleID, userID, chatID string, archived bool) error
 
+	// Clear deletes a chat room for this user: every message up to now stops being
+	// visible to them and the room leaves their list. One-sided and not recoverable.
+	// Messages sent after the cutoff arrive and display normally.
+	Clear(ctx context.Context, bundleID, userID, chatID string) error
+
 	GetBusinessCardOnly(ctx context.Context, bundleID string, before time.Duration) ([]*models.BusinessCardChat, error)
 }
 

--- a/store/chat.go
+++ b/store/chat.go
@@ -150,6 +150,34 @@ func (s *chatStore) SetHidden(ctx context.Context, chatID, userID string, hidden
 	return nil
 }
 
+// SetCleared deletes a chat room for one user: it stamps the delete cutoff and
+// archives the room in the same statement (rules R1 and R2).
+//
+// Everything created at or before cleared_at stops being visible to this user, for
+// good — the cutoff is never reset by later messages. Messages themselves are not
+// touched, so the other participant keeps the full history.
+//
+// Deleting also drops the unread count to zero (rule R3), for the same reason
+// archiving does: the room leaves the list and the messages that produced the count are
+// gone from this user's view.
+//
+// Calling it again on a room that has since received messages moves the cutoff forward,
+// which is what makes a second delete clear the newer messages too.
+func (s *chatStore) SetCleared(ctx context.Context, chatID, userID string) error {
+	query := `
+	UPDATE public.chat_thread
+	SET cleared_at=now(), hidden_at=now(), unread_count=0
+	WHERE chat_id=? AND sender_id=?
+	`
+	query = s.db.Rebind(query)
+	if _, err := s.db.Exec(query, chatID, userID); err != nil {
+		logging.Errorw(ctx, "clear chat thread failed", "err", err, "chatID", chatID, "userID", userID)
+		return err
+	}
+
+	return nil
+}
+
 func (s *chatStore) Pin(ctx context.Context, chatID, userID string, isPinned bool) error {
 	query := `
 	UPDATE public.chat_thread
@@ -578,7 +606,9 @@ func (s *chatStore) GetMessage(ctx context.Context, messageID string) (*models.M
 	return &msg, nil
 }
 
-func (s *chatStore) GetNewMessages(ctx context.Context, chatID string, after time.Time) ([]*models.Message, error) {
+// GetNewMessages returns everything in a room created after a given point, with the
+// caller's delete cutoff applied on top (rule R2).
+func (s *chatStore) GetNewMessages(ctx context.Context, chatID string, after time.Time, clearedAt *time.Time) ([]*models.Message, error) {
 
 	query := `
 	SELECT
@@ -593,13 +623,19 @@ func (s *chatStore) GetNewMessages(ctx context.Context, chatID string, after tim
 		media_ids,
 		reference_id	
 	FROM public.message
-	WHERE chat_id=? AND created_at>?
-	ORDER BY created_at DESC
-	`
+	WHERE chat_id=? AND created_at>?`
 	values := []interface{}{
 		chatID,
 		after,
 	}
+	// Rule R2. Strictly greater: a message created exactly at the cutoff stays hidden.
+	if clearedAt != nil {
+		query += ` AND created_at>?`
+		values = append(values, *clearedAt)
+	}
+	query += `
+	ORDER BY created_at DESC
+	`
 	query = s.db.Rebind(query)
 	rows, err := s.db.Queryx(query, values...)
 	if err != nil {
@@ -632,7 +668,12 @@ func (s *chatStore) GetNewMessages(ctx context.Context, chatID string, after tim
 	return msgs, nil
 }
 
-func (s *chatStore) GetMessages(ctx context.Context, chatID string, next string, count int) ([]*models.Message, error) {
+// GetMessages returns a page of a room's history, newest first.
+//
+// clearedAt is the caller's delete cutoff (rule R2). Filtering in SQL rather than after
+// the fact keeps the cursor arithmetic honest: a page of `count` rows is a page of rows
+// the caller can actually see.
+func (s *chatStore) GetMessages(ctx context.Context, chatID string, next string, count int, clearedAt *time.Time) ([]*models.Message, error) {
 
 	if next == "" {
 		// +2 seconds to prevent the last message is created at almost the same time with getting messages
@@ -651,15 +692,21 @@ func (s *chatStore) GetMessages(ctx context.Context, chatID string, next string,
 		media_ids,
 		reference_id
 	FROM public.message
-	WHERE chat_id=? AND created_at<TO_TIMESTAMP(?)
-	ORDER BY created_at DESC
-	LIMIT ?
-	`
+	WHERE chat_id=? AND created_at<TO_TIMESTAMP(?)`
 	values := []interface{}{
 		chatID,
 		next,
-		count,
 	}
+	// Rule R2. Strictly greater: a message created exactly at the cutoff stays hidden.
+	if clearedAt != nil {
+		query += ` AND created_at>?`
+		values = append(values, *clearedAt)
+	}
+	query += `
+	ORDER BY created_at DESC
+	LIMIT ?
+	`
+	values = append(values, count)
 	query = s.db.Rebind(query)
 	rows, err := s.db.Queryx(query, values...)
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -30,8 +30,8 @@ type Chat interface {
 	GetChatID(ctx context.Context, appID, senderID, receiverID string, postID *string, opts ...models.GetChatIDOptionFunc) (string, bool, error)
 	Read(ctx context.Context, userID, chatID string) error
 	GetMessage(ctx context.Context, messageID string) (*models.Message, error)
-	GetMessages(ctx context.Context, chatID string, next string, count int) ([]*models.Message, error)
-	GetNewMessages(ctx context.Context, chatID string, after time.Time) ([]*models.Message, error)
+	GetMessages(ctx context.Context, chatID string, next string, count int, clearedAt *time.Time) ([]*models.Message, error)
+	GetNewMessages(ctx context.Context, chatID string, after time.Time, clearedAt *time.Time) ([]*models.Message, error)
 	GetFirstMessages(ctx context.Context, opt []models.FirstMessageOption) (map[string]*models.Message, error)
 	AddMessage(ctx context.Context, userID, chatID, receiverID string, typ models.MessageType, body *string, mediaIDs []string, replyToMessageID *string, referenceID *string) (string, error)
 	AddMessages(ctx context.Context, userID, chatID, receiverID string, msgs []*models.Message) error
@@ -39,6 +39,7 @@ type Chat interface {
 	Annotate(ctx context.Context, chatID, userID string, status models.ChatAnnotation) error
 	Pin(ctx context.Context, chatID, userID string, isPinned bool) error
 	SetHidden(ctx context.Context, chatID, userID string, hidden bool) error
+	SetCleared(ctx context.Context, chatID, userID string) error
 	UpdateHireContact(ctx context.Context, chatID string, userID string, contact *models.HireContact) error
 	UpdateBusinessCardSnapshotID(ctx context.Context, chatID, snapshotID string) error
 	UpdateAccessStatus(ctx context.Context, chatID string, status models.AccessStatus) error


### PR DESCRIPTION
> **Stacked on #17** (archive), which is itself stacked on #16 (the spec). Base is `feat/chat-archive`, so this diff shows only the delete work. Merge the stack bottom-up and each PR retargets cleanly.

## What this does

Deleting clears every message up to now on the caller's side and hides the room from their list. One-sided and **not recoverable**: the other participant keeps the full history and is not notified. Messages sent after the cutoff arrive and display normally.

```go
Clear(ctx, bundleID, userID, chatID) error
```

> A and B have 10 messages → A deletes → B sends the 11th
> → **A sees 1 message, B sees 11.**

**No HTTP routes here — this is a library.** `DELETE /hire/chats/{id}/messages` lands in the three API repos once this is tagged.

## No message row is touched

`SetCleared` only stamps `cleared_at` and `hidden_at` on the caller's own `chat_thread` row. Every read then applies the cutoff:

| Read path | How |
|---|---|
| `GetMessages` | `AND created_at > ?` in SQL |
| `GetNewMessages` | same |
| `aggregateLastMessage` | returns nil when the preview falls before the cutoff |

Filtering in SQL rather than after the fact matters for the cursor: a page of `count` rows has to be a page of rows the caller can actually *see*, or paging silently returns short pages.

**Rule R2 costs no extra query.** Both message getters already looked the room up to check membership, and that row carries the cutoff — so it is just threaded through.

## The cutoff is never reset

This is what separates delete from archive. Archive is undone by the next message; delete is not. Calling delete again just moves the cutoff forward, which is how a second delete clears the newer messages too.

## Drive-by cleanup

The hand-rolled per-viewer visibility switches in `aggregateMessages` and `aggregateLastMessage` are replaced with the shared predicates from `models/chat_visibility.go`. That is what they were extracted for in #17; this is the payoff.

## Tests

**19 pass, 3 skip.** The three skips are the per-message-delete scenarios this SDK genuinely cannot run: the read side is fully implemented but nothing ever writes `DeletedBySender` / `DeletedByReceiver` (gap G4). megaphone is where those run today, and they pass there.

Worth a look:

- `TestNewMessageAfterDeleteShowsOnlyPostCutoffMessages` — the headline scenario, both sides asserted
- `TestLastMessagePreviewRespectsTheCutoff` — the chat list would otherwise happily preview a message the user just deleted, since `last_message_id` is shared state and still points at it
- `TestDeleteCutoffIsNeverReset` and `TestArchiveAndDeleteInteract`

## Deployment

The `cleared_at` column already ships in #17's migration, so there is no new DDL here. The tag-then-bump-all-three order from #17 still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)