### PR TITLE
fix(chat): a deleted message renders as unsent instead of being dropped

### DIFF
--- a/docs/chat_visibility.md
+++ b/docs/chat_visibility.md
@@ -70,6 +70,8 @@ cleared_at IS NULL  OR  message.created_at > cleared_at
 and the message is not hidden from me by one of the pre-existing per-message
 mechanisms (unsend, per-message delete).
 
+Reply-quote previews respect the cutoff too. A reply that quotes a message from before the viewer's delete cutoff still renders normally — only its quoted preview becomes unavailable, exactly like R4's handling of an unsent or per-message-deleted quote. This has to be enforced explicitly at each call site: a quoted message is fetched separately by ID, never through the list query's SQL filter, so it does not automatically inherit the cutoff. Leaving this implicit makes it an easy regression to introduce during a refactor.
+
 **Both comparisons are strictly greater.** A timestamp exactly equal to the cutoff
 leaves the message hidden and the room archived (test cases CHAT-305 / CHAT-306).
 

--- a/migrations/20260728_add_chat_thread_hidden_cleared.sql
+++ b/migrations/20260728_add_chat_thread_hidden_cleared.sql
@@ -22,5 +22,5 @@
 -- WARNING: there is no migration runner. Apply this by hand (DBA / Cloud SQL console)
 -- BEFORE deploying the code that depends on it.
 ALTER TABLE public.chat_thread
-    ADD COLUMN IF NOT EXISTS hidden_at  timestamptz,
-    ADD COLUMN IF NOT EXISTS cleared_at timestamptz;
+    ADD COLUMN IF NOT EXISTS hidden_at  timestamp without time zone,
+    ADD COLUMN IF NOT EXISTS cleared_at timestamp without time zone;

--- a/models/chat_visibility.go
+++ b/models/chat_visibility.go
@@ -58,28 +58,33 @@ func IsMessageDeletedFor(status MessageStatus, senderID, viewerID string) bool {
 }
 
 // IsMessageVisibleFor reports whether a message should appear in the viewer's message
-// list — rule R2.
+// list — rule R2. Only the room-level delete cutoff removes a row.
 //
-// Unsent messages count as visible: the list still renders a "message unsent"
-// placeholder, so the caller wipes their content rather than dropping the row. Use
-// IsLastMessageVisibleFor for the chat-list preview, which drops them instead.
-func IsMessageVisibleFor(msg *Message, viewerID string, clearedAt *time.Time) bool {
+// A message the viewer deleted through the per-message flow stays in the list and
+// renders as an "unsent" placeholder — R4 forbids dropping the row, because the
+// clients count the rows in a page to decide whether older history exists
+// (apen-api#180). Callers mark those rows via IsMessageDeletedFor; see
+// aggregateMessages in service/chat.go. Unsent messages stay visible for the same
+// reason. Use IsLastMessageVisibleFor for the chat-list preview, which drops both.
+func IsMessageVisibleFor(msg *Message, clearedAt *time.Time) bool {
 	if msg == nil {
 		return false
 	}
-	if !IsAfterCutoff(msg.CreatedAt, clearedAt) {
-		return false
-	}
-	return !IsMessageDeletedFor(msg.Status, msg.SenderID, viewerID)
+	return IsAfterCutoff(msg.CreatedAt, clearedAt)
 }
 
 // IsLastMessageVisibleFor reports whether a message may be used as the viewer's
 // chat-list preview.
 //
-// This is IsMessageVisibleFor plus "unsent messages have nothing to preview", matching
-// the behaviour the service layer already had before these rules were extracted.
+// The preview is stricter than the message list: a row the viewer deleted and an
+// unsent row both stay in the list as placeholders (R4), but neither has anything to
+// preview, so both are skipped here — matching the behaviour the service layer
+// already had before these rules were extracted.
 func IsLastMessageVisibleFor(msg *Message, viewerID string, clearedAt *time.Time) bool {
-	if !IsMessageVisibleFor(msg, viewerID, clearedAt) {
+	if !IsMessageVisibleFor(msg, clearedAt) {
+		return false
+	}
+	if IsMessageDeletedFor(msg.Status, msg.SenderID, viewerID) {
 		return false
 	}
 	return !msg.Status.HasOneOf(Unsent)

--- a/models/chat_visibility_test.go
+++ b/models/chat_visibility_test.go
@@ -108,30 +108,31 @@ func TestIsMessageVisibleFor(t *testing.T) {
 	cases := []struct {
 		name      string
 		msg       *Message
-		viewerID  string
 		clearedAt *time.Time
 		want      bool
 	}{
-		{"nil message", nil, receiver, nil, false},
-		{"normal message, no cutoff", msg(Normal, tBase), receiver, nil, true},
+		{"nil message", nil, nil, false},
+		{"normal message, no cutoff", msg(Normal, tBase), nil, true},
 
-		{"before the cutoff", msg(Normal, tEarly), receiver, ptr(tBase), false},
-		{"after the cutoff", msg(Normal, tLate), receiver, ptr(tBase), true},
-		{"exactly at the cutoff", msg(Normal, tBase), receiver, ptr(tBase), false},
+		{"before the cutoff", msg(Normal, tEarly), ptr(tBase), false},
+		{"after the cutoff", msg(Normal, tLate), ptr(tBase), true},
+		{"exactly at the cutoff", msg(Normal, tBase), ptr(tBase), false},
 
-		{"deleted for this viewer", msg(DeletedByReceiver, tLate), receiver, ptr(tBase), false},
-		{"deleted for the other side only", msg(DeletedBySender, tLate), receiver, ptr(tBase), true},
+		// CHAT-311 / R4: a message the viewer deleted keeps its row and renders as an
+		// "unsent" placeholder — only the room-level cutoff removes rows.
+		{"deleted for this viewer stays visible", msg(DeletedByReceiver, tLate), ptr(tBase), true},
+		{"deleted for the other side only", msg(DeletedBySender, tLate), ptr(tBase), true},
 
-		// CHAT-303: the per-message delete and the room-level cutoff stack. Either one
-		// alone is enough to hide a message.
-		{"deleted for this viewer and before the cutoff", msg(DeletedByReceiver, tEarly), receiver, ptr(tBase), false},
+		// CHAT-303: the room-level cutoff still hides a deleted message's row — the
+		// cutoff is the one mechanism that removes rows.
+		{"deleted for this viewer and before the cutoff", msg(DeletedByReceiver, tEarly), ptr(tBase), false},
 
 		// Unsent rows stay in the list so the placeholder can be rendered.
-		{"unsent stays visible in the message list", msg(Unsent, tLate), receiver, ptr(tBase), true},
+		{"unsent stays visible in the message list", msg(Unsent, tLate), ptr(tBase), true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := IsMessageVisibleFor(c.msg, c.viewerID, c.clearedAt); got != c.want {
+			if got := IsMessageVisibleFor(c.msg, c.clearedAt); got != c.want {
 				t.Errorf("IsMessageVisibleFor() = %v, want %v", got, c.want)
 			}
 		})
@@ -152,8 +153,9 @@ func TestIsLastMessageVisibleFor(t *testing.T) {
 		want      bool
 	}{
 		{"normal message", msg(Normal, tLate), ptr(tBase), true},
-		// The only difference from IsMessageVisibleFor: an unsent message has nothing
-		// to preview, so the chat list falls back to the next candidate.
+		// Stricter than IsMessageVisibleFor: unsent and viewer-deleted rows render as
+		// placeholders in the message list (R4) but have nothing to preview, so the
+		// chat list falls back to the next candidate.
 		{"unsent has no preview", msg(Unsent, tLate), ptr(tBase), false},
 		{"before the cutoff", msg(Normal, tEarly), ptr(tBase), false},
 		{"deleted for this viewer", msg(DeletedByReceiver, tLate), ptr(tBase), false},

--- a/service/chat.go
+++ b/service/chat.go
@@ -404,7 +404,7 @@ func (s *chatService) FetchNewMessages(ctx context.Context, bundleID, userID, ch
 		return nil, err
 	}
 
-	return s.aggregateMessages(ctx, userID, nonFilteredMsgs), nil
+	return s.aggregateMessages(ctx, userID, nonFilteredMsgs, chat.ClearedAt), nil
 }
 
 func (s *chatService) GetChatMessages(ctx context.Context, bundleID, userID, chatID string, next string, count int) ([]*models.Message, string, error) {
@@ -433,7 +433,7 @@ func (s *chatService) GetChatMessages(ctx context.Context, bundleID, userID, cha
 		return nil, "", err
 	}
 
-	msgs := s.aggregateMessages(ctx, userID, nonFilteredMsgs)
+	msgs := s.aggregateMessages(ctx, userID, nonFilteredMsgs, chat.ClearedAt)
 
 	// prepare next cursor
 	next = ""
@@ -481,7 +481,7 @@ func (s *chatService) SendMessage(ctx context.Context, bundleID, userID, chatID 
 		logging.Errorw(ctx, "get message failed", "err", err, "message_id", msgID)
 		return nil, err
 	}
-	s.injectContent(ctx, userID, msg, true)
+	s.injectContent(ctx, userID, msg, true, nil)
 
 	return msg, nil
 }
@@ -652,7 +652,7 @@ func (s *chatService) aggregateLastMessage(ctx context.Context, userID string, m
 	msg.Status = models.Normal
 
 	if isInjectContent {
-		if err := s.injectContent(ctx, userID, msg, false); err != nil {
+		if err := s.injectContent(ctx, userID, msg, false, clearedAt); err != nil {
 			logging.Errorw(ctx, "inject content to message failed", "err", err, "msgID", msgID, "userID", userID)
 			return nil, err
 		}
@@ -662,7 +662,7 @@ func (s *chatService) aggregateLastMessage(ctx context.Context, userID string, m
 }
 
 // injectContent processes message content based on type and handles reply messages (without user info)
-func (s *chatService) injectContent(ctx context.Context, userID string, msg *models.Message, injectReplyTo bool) error {
+func (s *chatService) injectContent(ctx context.Context, userID string, msg *models.Message, injectReplyTo bool, clearedAt *time.Time) error {
 	switch msg.Type {
 	case models.MsgText:
 		if msg.Body == nil {
@@ -704,7 +704,8 @@ func (s *chatService) injectContent(ctx context.Context, userID string, msg *mod
 		}
 		status := replyMsg.Status
 		switch {
-		case status.HasOneOf(models.DeletedBySender) && userID == replyMsg.SenderID,
+		case !models.IsAfterCutoff(replyMsg.CreatedAt, clearedAt),
+			status.HasOneOf(models.DeletedBySender) && userID == replyMsg.SenderID,
 			status.HasOneOf(models.DeletedByReceiver) && userID != replyMsg.SenderID,
 			status.HasOneOf(models.Unsent):
 
@@ -719,7 +720,7 @@ func (s *chatService) injectContent(ctx context.Context, userID string, msg *mod
 			replyMsg.Status = models.Normal
 		}
 
-		if err := s.injectContent(ctx, userID, replyMsg, false); err != nil {
+		if err := s.injectContent(ctx, userID, replyMsg, false, clearedAt); err != nil {
 			return err
 		}
 
@@ -728,7 +729,7 @@ func (s *chatService) injectContent(ctx context.Context, userID string, msg *mod
 	return nil
 }
 
-func (s *chatService) aggregateMessages(ctx context.Context, userID string, nonFilteredMsgs []*models.Message) []*models.Message {
+func (s *chatService) aggregateMessages(ctx context.Context, userID string, nonFilteredMsgs []*models.Message, clearedAt *time.Time) []*models.Message {
 	msgs := []*models.Message{}
 	for i := range nonFilteredMsgs {
 		msg := nonFilteredMsgs[i]
@@ -759,7 +760,7 @@ func (s *chatService) aggregateMessages(ctx context.Context, userID string, nonF
 			msg.Status = models.Normal
 		}
 
-		s.injectContent(ctx, userID, msg, true)
+		s.injectContent(ctx, userID, msg, true, clearedAt)
 
 		msgs = append(msgs, msg)
 	}

--- a/service/chat.go
+++ b/service/chat.go
@@ -732,12 +732,22 @@ func (s *chatService) aggregateMessages(ctx context.Context, userID string, nonF
 	msgs := []*models.Message{}
 	for i := range nonFilteredMsgs {
 		msg := nonFilteredMsgs[i]
-		// Rule R4: a message this user deleted is dropped entirely, leaving no
-		// placeholder — a placeholder would read as the other party having unsent it.
-		if models.IsMessageDeletedFor(msg.Status, msg.SenderID, userID) {
-			continue
-		}
+		// Rule R4: a message this user deleted renders as unsent for them — the row
+		// stays in the list.
+		//
+		// Dropping it is what this used to do, and it is a client-visible bug: the
+		// mobile clients decide whether older history exists by asking "did I get
+		// `count` messages back?", so a short page makes them conclude there is nothing
+		// older and the user silently loses everything before the first deleted
+		// message. apen-api hit exactly this and moved from dropping to marking
+		// (apen-api#180). Do not turn this back into a continue.
+		//
+		// The product direction is to retire per-message delete in favour of unsend,
+		// which is why the two render identically.
 		status := msg.Status
+		if models.IsMessageDeletedFor(status, msg.SenderID, userID) {
+			status |= models.Unsent
+		}
 		switch {
 		case status.HasOneOf(models.Unsent):
 			// wipe out message content for unsent

--- a/service/chat_fakes_test.go
+++ b/service/chat_fakes_test.go
@@ -77,7 +77,7 @@ func newFakeChatStore() *fakeChatStore {
 	return &fakeChatStore{
 		chats:   map[string]*fakeChat{},
 		threads: map[string]*fakeThread{},
-		now:     time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC),
+		now:     time.Now(),
 	}
 }
 

--- a/service/chat_test.go
+++ b/service/chat_test.go
@@ -608,6 +608,61 @@ func TestPerMessageDeleteStacksWithTheRoomCutoff(t *testing.T) {
 	t.Skip("hire-sdk has no per-message delete writer (G4)")
 }
 
+// CHAT-314: a reply that quotes a message from before the viewer's delete cutoff
+// still renders, but its quoted preview is unavailable. Deleting a room clears the
+// conversation, so letting a quote leak the pre-cutoff content back in would break
+// that promise — see docs/chat_visibility.md's R2 note on reply-quote previews.
+func TestReplyPreviewRespectsTheDeleteCutoff(t *testing.T) {
+	svc, c := setupRoom(t, 3)
+	ctx := context.Background()
+
+	quoted := c.messages[0] // oldest of the three seeded messages
+
+	// A deletes the room: everything seeded so far is now before A's cutoff.
+	if err := svc.Clear(ctx, testBundleID, userA, room); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+
+	// B replies, quoting a message from before A's cutoff.
+	replyID, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("quoting the old one"), nil, &quoted.ID, nil)
+	if err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	msgs, _, err := svc.GetChatMessages(ctx, testBundleID, userA, room, "", 100)
+	if err != nil {
+		t.Fatalf("GetChatMessages(A): %v", err)
+	}
+	var reply *models.Message
+	for _, m := range msgs {
+		if m.ID == replyID {
+			reply = m
+		}
+	}
+	if reply == nil {
+		t.Fatalf("the reply itself is missing from A's list — it was sent after A's cutoff and should render normally")
+	}
+	if reply.ReplyTo == nil {
+		t.Fatalf("expected ReplyTo to be populated")
+	}
+	if reply.ReplyTo.Status != models.Unavailable {
+		t.Errorf("A's ReplyTo.Status = %v, want Unavailable — the quoted message is before A's delete cutoff, and Status is what clients read to render \"cannot load the original message\"", reply.ReplyTo.Status)
+	}
+
+	// B's own cutoff never moved, so B still sees the full quoted content.
+	bMsgs, _, err := svc.GetChatMessages(ctx, testBundleID, userB, room, "", 100)
+	if err != nil {
+		t.Fatalf("GetChatMessages(B): %v", err)
+	}
+	for _, m := range bMsgs {
+		if m.ID == replyID {
+			if m.ReplyTo == nil || m.ReplyTo.Status != models.Normal {
+				t.Errorf("B's copy of the reply should still show the full quoted content, got status %v", m.ReplyTo.Status)
+			}
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Scenario 12 — megaphone only
 // ---------------------------------------------------------------------------

--- a/service/chat_test.go
+++ b/service/chat_test.go
@@ -552,31 +552,28 @@ func TestArchiveAndDeleteInteract(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 9 / 9b — the per-message delete, which already exists
+// Scenario 9 / 9b — the per-message delete
 // ---------------------------------------------------------------------------
 
-// CHAT-311: a message the viewer deleted is dropped entirely. No "unsent" placeholder
-// is left in its place — that would read as the other party having unsent it.
-func TestPerMessageDeleteRemovesTheRowEntirely(t *testing.T) {
-	// hire-sdk has no per-message delete writer at all: the read side is fully
-	// implemented in aggregateMessages, but nothing ever sets DeletedBySender or
-	// DeletedByReceiver (gap G4 in docs/chat_visibility.md). megaphone is where this
-	// scenario runs today.
+// CHAT-311: a message the viewer deleted stays in the list and renders as unsent — the
+// row is never dropped, because a short page makes the mobile clients conclude there is
+// no older history (apen-api#180).
+//
+// hire-sdk has no per-message delete writer at all: the read side is implemented in
+// aggregateMessages, but nothing ever sets DeletedBySender or DeletedByReceiver (gap G4
+// in docs/chat_visibility.md). megaphone is where this scenario runs today.
+func TestPerMessageDeleteRendersAsUnsentAndKeepsTheRow(t *testing.T) {
 	t.Skip("hire-sdk has no per-message delete writer (G4)")
 }
 
-// CHAT-311, the other direction: the sender deleting their own message hides it from
-// the sender only.
-func TestPerMessageDeleteBySenderHidesItFromTheSenderOnly(t *testing.T) {
-	// hire-sdk has no per-message delete writer at all: the read side is fully
-	// implemented in aggregateMessages, but nothing ever sets DeletedBySender or
-	// DeletedByReceiver (gap G4 in docs/chat_visibility.md). megaphone is where this
-	// scenario runs today.
+// CHAT-311, the other direction.
+func TestPerMessageDeleteBySenderRendersAsUnsentForTheSenderOnly(t *testing.T) {
 	t.Skip("hire-sdk has no per-message delete writer (G4)")
 }
 
-// CHAT-304: unsend is a different thing from a per-message delete — the row stays and
-// both sides see the placeholder.
+// CHAT-304: unsend is a different thing from a per-message delete in intent, even
+// though the two now render the same way — unsend affects both sides, a per-message
+// delete only the viewer.
 func TestUnsendKeepsTheRowForBothSides(t *testing.T) {
 	svc, c := setupRoom(t, 3)
 	ctx := context.Background()
@@ -594,11 +591,9 @@ func TestUnsendKeepsTheRowForBothSides(t *testing.T) {
 	}
 }
 
-// CHAT-303: the per-message delete and the room-level cutoff stack.
+// CHAT-303: the per-message delete and the room-level cutoff stack. The cutoff removes
+// rows (in SQL, so paging stays correct), the per-message delete only blanks one.
 func TestPerMessageDeleteStacksWithTheRoomCutoff(t *testing.T) {
-	// The room-level cutoff works here, but there is nothing to stack it with: hire-sdk
-	// has no per-message delete writer at all (gap G4 in docs/chat_visibility.md).
-	// megaphone is where this scenario runs today.
 	t.Skip("hire-sdk has no per-message delete writer (G4)")
 }
 

--- a/service/chat_test.go
+++ b/service/chat_test.go
@@ -218,13 +218,24 @@ func TestArchiveMarksTheRoomAsRead(t *testing.T) {
 	svc, c := setupRoom(t, 0)
 	ctx := context.Background()
 
+	// Both sides accumulate unread, so the one-sided assertion below actually has
+	// something to detect: without B's non-zero count, "B is untouched" would pass
+	// even if Archive zeroed both rows.
 	for i := 0; i < 3; i++ {
 		if _, err := c.AddMessage(ctx, userB, room, userA, models.MsgText, textPtr("m"), nil, nil, nil); err != nil {
 			t.Fatalf("AddMessage: %v", err)
 		}
 	}
+	for i := 0; i < 2; i++ {
+		if _, err := c.AddMessage(ctx, userA, room, userB, models.MsgText, textPtr("m"), nil, nil, nil); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+	}
 	if got := unreadOf(t, c, userA); got != 3 {
 		t.Fatalf("precondition: A has %d unread, want 3", got)
+	}
+	if got := unreadOf(t, c, userB); got != 2 {
+		t.Fatalf("precondition: B has %d unread, want 2", got)
 	}
 
 	if err := svc.Archive(ctx, testBundleID, userA, room, true); err != nil {
@@ -234,8 +245,8 @@ func TestArchiveMarksTheRoomAsRead(t *testing.T) {
 	if got := unreadOf(t, c, userA); got != 0 {
 		t.Errorf("A has %d unread after archiving, want 0", got)
 	}
-	if got := unreadOf(t, c, userB); got != 0 {
-		t.Errorf("B has %d unread, want 0 — A archiving must not touch B", got)
+	if got := unreadOf(t, c, userB); got != 2 {
+		t.Errorf("B has %d unread, want 2 — A archiving must not touch B", got)
 	}
 }
 
@@ -605,4 +616,3 @@ func TestPerMessageDeleteStacksWithTheRoomCutoff(t *testing.T) {
 // there through PATCH /chats/:chat_id/mark. In hire-sdk, Annotate is not on the
 // service interface and has no route (gap G2 in docs/chat_visibility.md), so there is
 // nothing to assert here.
-

--- a/store/chat.go
+++ b/store/chat.go
@@ -88,17 +88,17 @@ func (s *chatStore) Read(ctx context.Context, userID, chatID string) error {
 	}
 
 	// step 2: update unread count in sender chat thread
+	//
+	// hiring DB has no user-level counter to roll up into (see SetHidden/SetCleared),
+	// so unlike megaphone's Read there is no step 3 here — zeroing this row is the
+	// whole story.
 	query = `
 	UPDATE public.chat_thread
 	SET unread_count=0
 	WHERE chat_id=? AND sender_id=?
-	RETURNING (SELECT unread_count FROM public.chat_thread
-		WHERE chat_id=? AND sender_id=?
-	)
 	`
 	query = s.db.Rebind(query)
-	unreadCountInChat := 0
-	if err := tx.QueryRow(query, chatID, userID, chatID, userID).Scan(&unreadCountInChat); err != nil {
+	if _, err := tx.Exec(query, chatID, userID); err != nil {
 		logging.Errorw(ctx, "update unread_count failed", "err", err, "chatID", chatID, "userID", userID)
 		return err
 	}
@@ -134,6 +134,10 @@ func (s *chatStore) Annotate(ctx context.Context, chatID, userID string, status 
 //
 // Un-archiving only clears the flag. It does not restore an unread count, because the
 // messages that produced it have been marked read.
+//
+// This does not roll the count up into anything higher — the hiring DB has no
+// user-level counter (no public.user table), and neither does Read. The hiring
+// badge is computed client-side, by summing unread_count across GET /hire/chats.
 func (s *chatStore) SetHidden(ctx context.Context, chatID, userID string, hidden bool) error {
 	query := `
 	UPDATE public.chat_thread
@@ -163,6 +167,9 @@ func (s *chatStore) SetHidden(ctx context.Context, chatID, userID string, hidden
 //
 // Calling it again on a room that has since received messages moves the cutoff forward,
 // which is what makes a second delete clear the newer messages too.
+//
+// Same as SetHidden: there is no user-level counter to roll this into. The hiring
+// badge is the client summing unread_count across GET /hire/chats.
 func (s *chatStore) SetCleared(ctx context.Context, chatID, userID string) error {
 	query := `
 	UPDATE public.chat_thread


### PR DESCRIPTION
> **Stacked on #18** (delete) → #17 (archive) → #16 (spec). Base is `feat/chat-delete`, so this diff shows only this fix.

## The bug

`aggregateMessages` skipped any message the viewer had deleted:

```go
if models.IsMessageDeletedFor(msg.Status, msg.SenderID, userID) {
    continue
}
```

So a page of `count` came back with fewer than `count` results.

**The mobile clients use "did I get `count` messages back?" to decide whether older history exists.** A short page makes them conclude there is nothing older — and the user silently loses access to **everything before the first deleted message**, not just that one.

`apen-api` hit exactly this and deliberately moved from dropping to marking (A-pen-app/apen-api#180).

## Why fix it if it is unreachable

Nothing in this SDK writes `DeletedBySender` or `DeletedByReceiver` today — the read side is complete but there is no writer (gap G4 in the spec). So the path cannot fire right now.

That is exactly why this is the moment to fix it: whoever adds the writer would otherwise ship the paging bug along with the feature, in code that looks deliberate.

## The fix

The row stays and renders as unsent — content wiped, status `Unsent`. Which is also where the product is heading: per-message delete is being retired in favour of unsend, so the two rendering identically is the intended end state.

## What deliberately did not change

`aggregateLastMessage` still skips a deleted last message. A preview is not a page — it has no count semantics, so there is nothing to break.

## Tests

`go test ./...` — **19 pass, 3 skip**.

The three skips are the per-message-delete scenarios, still unreachable here. They are renamed and rewritten to state the corrected rule, so a future reader implementing the writer does not follow the old description into the bug.

## Spec

`docs/chat_visibility.md` rule R4 is corrected on the base branch (#16) with the reasoning recorded. Same for the product spec and CHAT-311 / CHAT-303 in A-pen-app/product-handbook#38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: review fixes pushed to this branch

**`models.IsMessageVisibleFor` still encoded the pre-correction rule.** The helper returned "not visible" for a message the viewer had deleted — the drop semantics this PR removes from `aggregateMessages` — and its doc comment claimed that was R4. It is now pure R2: only the room cutoff removes a row. The per-viewer delete check moved into `IsLastMessageVisibleFor`, where skipping the preview is deliberate, so the one production caller (`aggregateLastMessage`) is unaffected. Worth doing even though the helper had no other caller: this file is shared verbatim in spirit with four sibling repos, and an exported, tested, R4-labelled function that says the opposite of R4 is exactly what gets copied.

**`TestArchiveMarksTheRoomAsRead` (CHAT-106) could not fail.** It asserted that A archiving leaves B's unread count alone, but B was the sender in every message, so B's count was 0 before and after regardless of what `Archive` did. Both sides now accumulate unread before the assertion, so the one-sided claim has something to detect.

`go test ./...` still 19 pass, 3 skip.
