### PR TITLE
feat: 求職名片年資 jsonb key 改名 year_of_experience + 帶 updated_at (PS-3273)

### DIFF
--- a/models/business_card.go
+++ b/models/business_card.go
@@ -20,26 +20,28 @@ type BusinessCardContent struct {
 	CurrentOrganization *string `json:"current_organization,omitempty"`
 	CurrentJobTitle     *string `json:"current_job_title,omitempty"`
 
-	// ExperienceYears is apen-only, mirroring user.year_of_experience in apen's
+	// YearOfExperience is apen-only, mirroring user.year_of_experience in apen's
 	// main DB with its sentinel encoding: 0 = less than 1 year (also
 	// no-experience and students), 21 = more than 20 years. Never render the
 	// raw value — decode via FormatExperienceYears.
 	//
-	// The Go field keeps the ExperienceYears name even though the wire/jsonb key
-	// is year_of_experience: YearOfExperience* is already taken by the 12-step
-	// YearOfExperienceType ordinals in resume.go, which mean something else.
-	ExperienceYears *int `json:"year_of_experience,omitempty"`
+	// ResumeContent.YearOfExperience carries the SAME business concept under the
+	// same name and jsonb key, but in the legacy 12-step encoding
+	// (YearOfExperienceType, 0..11). The Go type is what tells them apart: *int
+	// here, YearOfExperienceType there. Never assign one to the other without
+	// converting — the two ranges overlap, so a mix-up is silent.
+	YearOfExperience *int `json:"year_of_experience,omitempty"`
 
-	// ExperienceYearsUpdatedAt stamps when ExperienceYears was last set. The card
-	// stores a BASELINE; the value shown to users auto-increments from this
+	// YearOfExperienceUpdatedAt stamps when YearOfExperience was last set. The
+	// card stores a BASELINE; the value shown to users auto-increments from this
 	// timestamp (effective = baseline + whole years elapsed, capped by position).
 	// apen keeps the same pair on user and on the social card so each surface
 	// computes the effective value independently — see apen's
 	// models.EffectiveExperienceYears. nil means "never set, do not increment".
-	ExperienceYearsUpdatedAt *time.Time `json:"year_of_experience_updated_at,omitempty"`
+	YearOfExperienceUpdatedAt *time.Time `json:"year_of_experience_updated_at,omitempty"`
 
 	// ExperienceRange is the nurse / phar range-based tenure; mutually
-	// exclusive with ExperienceYears. Range-based tenure is a fixed bucket and
+	// exclusive with YearOfExperience. Range-based tenure is a fixed bucket and
 	// does NOT auto-increment, so it carries no updated-at stamp.
 	ExperienceRange *ExperienceRange `json:"experience_range,omitempty"`
 

--- a/models/business_card.go
+++ b/models/business_card.go
@@ -20,14 +20,27 @@ type BusinessCardContent struct {
 	CurrentOrganization *string `json:"current_organization,omitempty"`
 	CurrentJobTitle     *string `json:"current_job_title,omitempty"`
 
-	// ExperienceYears is apen-only, mirroring user.experience_years in apen's
+	// ExperienceYears is apen-only, mirroring user.year_of_experience in apen's
 	// main DB with its sentinel encoding: 0 = less than 1 year (also
 	// no-experience and students), 21 = more than 20 years. Never render the
 	// raw value — decode via FormatExperienceYears.
-	ExperienceYears *int `json:"experience_years,omitempty"`
+	//
+	// The Go field keeps the ExperienceYears name even though the wire/jsonb key
+	// is year_of_experience: YearOfExperience* is already taken by the 12-step
+	// YearOfExperienceType ordinals in resume.go, which mean something else.
+	ExperienceYears *int `json:"year_of_experience,omitempty"`
+
+	// ExperienceYearsUpdatedAt stamps when ExperienceYears was last set. The card
+	// stores a BASELINE; the value shown to users auto-increments from this
+	// timestamp (effective = baseline + whole years elapsed, capped by position).
+	// apen keeps the same pair on user and on the social card so each surface
+	// computes the effective value independently — see apen's
+	// models.EffectiveExperienceYears. nil means "never set, do not increment".
+	ExperienceYearsUpdatedAt *time.Time `json:"year_of_experience_updated_at,omitempty"`
 
 	// ExperienceRange is the nurse / phar range-based tenure; mutually
-	// exclusive with ExperienceYears.
+	// exclusive with ExperienceYears. Range-based tenure is a fixed bucket and
+	// does NOT auto-increment, so it carries no updated-at stamp.
 	ExperienceRange *ExperienceRange `json:"experience_range,omitempty"`
 
 	// PreferredLocations is dual-written with the resume's preferred_locations:

--- a/models/experience.go
+++ b/models/experience.go
@@ -3,8 +3,14 @@ package models
 import "strconv"
 
 // Sentinel values for the apen absolute-tenure encoding used by
-// BusinessCardContent.ExperienceYears (and user.experience_years in apen's
+// BusinessCardContent.YearOfExperience (and user.year_of_experience in apen's
 // main DB). Values in between are literal year counts.
+//
+// These keep the ExperienceYears* prefix rather than following the field
+// rename: YearOfExperienceLessThanOne is already the 12-step ordinal for the
+// same bucket in resume.go, and two constants of that name cannot coexist.
+// The prefix difference is the reminder that these belong to the 0..21
+// encoding, not the 0..11 one.
 const (
 	ExperienceYearsLessThanOne = 0  // "1年以下"; also covers no-experience and students
 	ExperienceYearsTwentyPlus  = 21 // "20年以上"; never a literal year count


### PR DESCRIPTION
## 為什麼

PS-3271 把 apen 的絕對年資從 PS-3132 新開的 `user.experience_years` 搬回既有的 `user.year_of_experience`，並讓所有介面統一用這個名字。求職名片的年資存在 `business_card.content` jsonb，所以 key 跟著改。

## 變更

| 項目 | before | after |
|---|---|---|
| 欄位 | `BusinessCardContent.ExperienceYears` | **`YearOfExperience`** |
| jsonb / wire key | `experience_years` | **`year_of_experience`** |
| 新增欄位 | — | **`YearOfExperienceUpdatedAt`**（key `year_of_experience_updated_at`） |

欄位名、jsonb key、apen DB 欄位名三者現在一致。

新增 `updated_at` 的原因：卡片存的是 **baseline**，三處介面（apen `user`、apen 社交名片、求職名片）各自換算有效值（baseline + 完整年數，再套職級上限），所以每一處都要自己的時間戳。

## 與履歷 12 階 ordinal 同名 —— 刻意接受

`ResumeContent.YearOfExperience` 早就用同一個 key 存 12 階 ordinal。兩者在**商業意義上是同一件事**（使用者的年資），只是編碼不同，所以同名成立，用 Go 型別區分：

| 位置 | key | 型別 | 值域 |
|---|---|---|---|
| `resume.content` | `year_of_experience` | `YearOfExperienceType` | 0..11（12 階區間序號） |
| `business_card.content` | `year_of_experience` | `*int` | 0..21（絕對年資） |

⚠️ 同一個 `hiring` DB、相鄰兩表、**值域重疊** → 兩者搞混不會編譯錯也不會 runtime 錯，只會靜默寫錯資料。已在 `YearOfExperience` 的 doc comment 寫明這點與「不得未轉換就互相指派」。

## 常數維持 `ExperienceYears*` 前綴

`ExperienceYearsLessThanOne` / `ExperienceYearsTwentyPlus` / `FormatExperienceYears` 不跟著改名 —— `YearOfExperienceLessThanOne` 確實已被 `models/resume.go:56` 的 12 階 ordinal 佔用（同樣是「1年以下」這個 bucket，但值是 1），兩個同名常數無法共存。註解已改成：這個前綴現在的作用是標記「這是 0..21 編碼，不是 0..11」。

（本 PR 第一版曾用「`YearOfExperience*` 已被佔用」當作**欄位**不改名的理由，那是錯的 —— struct 欄位與 package 常數不同命名空間，撞名的只有常數。已於 `aad2912` 更正。）

## 不動的部分

- `ExperienceRange`（nurse/phar 6 階區間）完全不動，**也不加時間戳** —— 區間制不會自動遞增
- nurse/phar 只需要升版，程式碼零改動（已確認兩支 repo 除 generated docs 外零引用）
- **沒有動任何 SQL**：`content` 透過 `driver.Valuer` 整包 marshal，沒有任何 query 把 jsonb key 寫成字面值

## 驗證

`go build ./...` / `go test ./...` 通過。

## ⚠️ 既有資料

PS-3132 期間寫進 `business_card.content` 的 `experience_years` key 在改名後會讀成 nil。該功能前端尚未上線（社交名片仍送 12 階序號、求職名片還沒有年資欄位），實務上應無正式資料；PS-3274 的 migration §7 帶了 defensive 的 jsonb key rename 處理 dev 資料。

## 後續

merge 後需 tag **v1.3.19**，apen-api（PS-3274）、nurse-api / phar-api（PS-3275）跟著升版。

## 相關

Parent: PS-3271 ｜ 依賴本 PR: PS-3274、PS-3275

🤖 Generated with [Claude Code](https://claude.com/claude-code)