### PR TITLE
feat: ListRelations 加上依職缺過濾與分頁

### DIFF
--- a/models/resume.go
+++ b/models/resume.go
@@ -183,7 +183,8 @@ type ResumeRelation struct {
 }
 
 // CursorTimeLayout renders a resume-list cursor. created_at is "timestamp
-// without time zone", so the cursor carries no offset either.
+// without time zone", so the cursor carries no offset either — it is only ever
+// built from a created_at that was read back, never from a wall clock.
 const CursorTimeLayout = "2006-01-02 15:04:05.999999"
 
 type ResumeStatus int

--- a/models/resume.go
+++ b/models/resume.go
@@ -182,10 +182,6 @@ type ResumeRelation struct {
 	Status     ResumeStatus `json:"-" db:"status"`
 }
 
-// CursorTimeLayout renders a relation cursor. created_at is "timestamp without
-// time zone", so the cursor carries no offset either.
-const CursorTimeLayout = "2006-01-02 15:04:05.999999"
-
 type ResumeStatus int
 
 const (
@@ -258,7 +254,7 @@ type ListRelationOption struct {
 	After   *time.Time
 	ChatIDs []string
 	PostIDs []string
-	Before  *string
+	Before  *time.Time
 	Count   int
 }
 type ListRelationOptionFunc func(*ListRelationOption) error
@@ -284,11 +280,12 @@ func ByPostIDs(postIDs []string) ListRelationOptionFunc {
 	}
 }
 
-// Paginate takes the newest count relations older than before (empty starts
-// from the newest). Ordering rides along: a LIMIT without one is arbitrary.
-func Paginate(before string, count int) ListRelationOptionFunc {
+// Paginate takes the newest count relations older than before (a zero time
+// starts from the newest). Ordering rides along: a LIMIT without one is
+// arbitrary.
+func Paginate(before time.Time, count int) ListRelationOptionFunc {
 	return func(opt *ListRelationOption) error {
-		if before != "" {
+		if !before.IsZero() {
 			opt.Before = &before
 		}
 		opt.Count = count

--- a/models/resume.go
+++ b/models/resume.go
@@ -182,9 +182,8 @@ type ResumeRelation struct {
 	Status     ResumeStatus `json:"-" db:"status"`
 }
 
-// CursorTimeLayout renders a resume-list cursor. created_at is "timestamp
-// without time zone", so the cursor carries no offset either — it is only ever
-// built from a created_at that was read back, never from a wall clock.
+// CursorTimeLayout renders a relation cursor. created_at is "timestamp without
+// time zone", so the cursor carries no offset either.
 const CursorTimeLayout = "2006-01-02 15:04:05.999999"
 
 type ResumeStatus int
@@ -258,6 +257,9 @@ func ByPostID(postID string) GetRelationOptionFunc {
 type ListRelationOption struct {
 	After   *time.Time
 	ChatIDs []string
+	PostIDs []string
+	Before  *string
+	Count   int
 }
 type ListRelationOptionFunc func(*ListRelationOption) error
 
@@ -271,6 +273,25 @@ func ByAfter(after time.Time) ListRelationOptionFunc {
 func ByChatIDs(chatIDs []string) ListRelationOptionFunc {
 	return func(opt *ListRelationOption) error {
 		opt.ChatIDs = chatIDs
+		return nil
+	}
+}
+
+func ByPostIDs(postIDs []string) ListRelationOptionFunc {
+	return func(opt *ListRelationOption) error {
+		opt.PostIDs = postIDs
+		return nil
+	}
+}
+
+// Paginate takes the newest count relations older than before (empty starts
+// from the newest). Ordering rides along: a LIMIT without one is arbitrary.
+func Paginate(before string, count int) ListRelationOptionFunc {
+	return func(opt *ListRelationOption) error {
+		if before != "" {
+			opt.Before = &before
+		}
+		opt.Count = count
 		return nil
 	}
 }

--- a/models/resume.go
+++ b/models/resume.go
@@ -182,6 +182,10 @@ type ResumeRelation struct {
 	Status     ResumeStatus `json:"-" db:"status"`
 }
 
+// CursorTimeLayout renders a resume-list cursor. created_at is "timestamp
+// without time zone", so the cursor carries no offset either.
+const CursorTimeLayout = "2006-01-02 15:04:05.999999"
+
 type ResumeStatus int
 
 const (

--- a/service/resume.go
+++ b/service/resume.go
@@ -85,6 +85,18 @@ func (s *resumeService) ListRelations(ctx context.Context, bundleID string, next
 		return []*models.ResumeRelation{}, next, nil
 	}
 
+	// An unparseable cursor starts from the newest rather than erroring: it is
+	// opaque to the caller, so a bad one means a stale or mangled link.
+	var before time.Time
+	if next != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, next)
+		if err != nil {
+			logging.Infow(ctx, "ignoring unparseable resume cursor", "next", next)
+		} else {
+			before = parsed
+		}
+	}
+
 	app, err := s.a.GetByBundleID(ctx, bundleID)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get app by bundle ID", "err", err, "bundleID", bundleID)
@@ -92,7 +104,7 @@ func (s *resumeService) ListRelations(ctx context.Context, bundleID string, next
 	}
 
 	// one extra row tells us whether a further page exists
-	relations, err := s.r.ListRelations(ctx, app.ID, append(opts, models.Paginate(next, count+1))...)
+	relations, err := s.r.ListRelations(ctx, app.ID, append(opts, models.Paginate(before, count+1))...)
 	if err != nil {
 		logging.Errorw(ctx, "failed to list resume relations", "err", err, "appID", app.ID)
 		return nil, "", err
@@ -101,7 +113,7 @@ func (s *resumeService) ListRelations(ctx context.Context, bundleID string, next
 	n := len(relations)
 	next = ""
 	if n > count {
-		next = relations[count-1].CreatedAt.Format(models.CursorTimeLayout)
+		next = relations[count-1].CreatedAt.Format(time.RFC3339Nano)
 		n = count
 	}
 	return relations[:n], next, nil

--- a/service/resume.go
+++ b/service/resume.go
@@ -77,6 +77,35 @@ func (s *resumeService) GetUserAppliedPostIDs(ctx context.Context, bundleID, use
 	return postIDs, nil
 }
 
+// ListReceived returns one page of relations for resumes sent to the given
+// posts, newest first, plus the cursor for the next page ("" when there is none).
+func (s *resumeService) ListReceived(ctx context.Context, bundleID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, string, error) {
+	if count == 0 {
+		return []*models.ResumeRelation{}, next, nil
+	}
+
+	app, err := s.a.GetByBundleID(ctx, bundleID)
+	if err != nil {
+		logging.Errorw(ctx, "failed to get app by bundle ID", "err", err, "bundleID", bundleID)
+		return nil, "", err
+	}
+
+	// one extra row tells us whether a further page exists
+	relations, err := s.r.ListReceived(ctx, app.ID, postIDs, next, count+1)
+	if err != nil {
+		logging.Errorw(ctx, "failed to list received resume relations", "err", err, "appID", app.ID)
+		return nil, "", err
+	}
+
+	n := len(relations)
+	next = ""
+	if n > count {
+		next = relations[count-1].CreatedAt.Format(models.CursorTimeLayout)
+		n = count
+	}
+	return relations[:n], next, nil
+}
+
 func (s *resumeService) GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error) {
 	snapshot, err := s.r.GetSnapshot(ctx, snapshotID)
 	if err != nil {

--- a/service/resume.go
+++ b/service/resume.go
@@ -77,11 +77,10 @@ func (s *resumeService) GetUserAppliedPostIDs(ctx context.Context, bundleID, use
 	return postIDs, nil
 }
 
-// ListReceived returns one page of relations for resumes sent to the given
-// posts, newest first, plus the cursor for the next page ("" when there is none).
-func (s *resumeService) ListReceived(ctx context.Context, bundleID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, string, error) {
-	// <=0, not ==0: a negative count would send LIMIT 0 and then index
-	// relations[count-1] out of range
+// ListRelations returns one page of relations, newest first, plus the cursor
+// for the next page ("" when there is none). Narrow it with the store's options.
+func (s *resumeService) ListRelations(ctx context.Context, bundleID string, next string, count int, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, string, error) {
+	// <=0, not ==0: a negative count would index relations[count-1]
 	if count <= 0 {
 		return []*models.ResumeRelation{}, next, nil
 	}
@@ -93,9 +92,9 @@ func (s *resumeService) ListReceived(ctx context.Context, bundleID string, postI
 	}
 
 	// one extra row tells us whether a further page exists
-	relations, err := s.r.ListReceived(ctx, app.ID, postIDs, next, count+1)
+	relations, err := s.r.ListRelations(ctx, app.ID, append(opts, models.Paginate(next, count+1))...)
 	if err != nil {
-		logging.Errorw(ctx, "failed to list received resume relations", "err", err, "appID", app.ID)
+		logging.Errorw(ctx, "failed to list resume relations", "err", err, "appID", app.ID)
 		return nil, "", err
 	}
 

--- a/service/resume.go
+++ b/service/resume.go
@@ -80,7 +80,9 @@ func (s *resumeService) GetUserAppliedPostIDs(ctx context.Context, bundleID, use
 // ListReceived returns one page of relations for resumes sent to the given
 // posts, newest first, plus the cursor for the next page ("" when there is none).
 func (s *resumeService) ListReceived(ctx context.Context, bundleID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, string, error) {
-	if count == 0 {
+	// <=0, not ==0: a negative count would send LIMIT 0 and then index
+	// relations[count-1] out of range
+	if count <= 0 {
 		return []*models.ResumeRelation{}, next, nil
 	}
 

--- a/service/resume_test.go
+++ b/service/resume_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -170,21 +171,28 @@ func TestListReceivedCursorFormat(t *testing.T) {
 	}
 }
 
-func TestListReceivedZeroCountSkipsTheStore(t *testing.T) {
-	r := &fakeResumeStore{relations: relationsAt(time.Now())}
-	s := NewResume(r, fakeAppStore{}, nil)
+// A negative count used to reach the store as LIMIT 0 and then index
+// relations[count-1] out of range. Callers inside this repo clamp it, but the
+// SDK is consumed by three others.
+func TestListReceivedNonPositiveCountSkipsTheStore(t *testing.T) {
+	for _, count := range []int{0, -1, -20} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			r := &fakeResumeStore{relations: relationsAt(time.Now(), time.Now())}
+			s := NewResume(r, fakeAppStore{}, nil)
 
-	got, next, err := s.ListReceived(context.Background(), "com.yoku.apen", []string{"post-1"}, "cursor", 0)
-	if err != nil {
-		t.Fatalf("ListReceived: %v", err)
-	}
-	if len(got) != 0 {
-		t.Errorf("returned %d relations, want none", len(got))
-	}
-	if next != "cursor" {
-		t.Errorf("next = %q, want the cursor handed in", next)
-	}
-	if r.gotCount != 0 {
-		t.Error("store was queried for a zero-sized page")
+			got, next, err := s.ListReceived(context.Background(), "com.yoku.apen", []string{"post-1"}, "cursor", count)
+			if err != nil {
+				t.Fatalf("ListReceived: %v", err)
+			}
+			if len(got) != 0 {
+				t.Errorf("returned %d relations, want none", len(got))
+			}
+			if next != "cursor" {
+				t.Errorf("next = %q, want the cursor handed in", next)
+			}
+			if r.gotCount != 0 {
+				t.Error("store was queried for a non-positive page")
+			}
+		})
 	}
 }

--- a/service/resume_test.go
+++ b/service/resume_test.go
@@ -2,13 +2,24 @@ package service
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/A-pen-app/hire-sdk/models"
 	"github.com/A-pen-app/hire-sdk/store"
+	"github.com/A-pen-app/logging"
 )
+
+// The service logs unconditionally on some paths, and logging.Infow panics on
+// a nil zap logger.
+func TestMain(m *testing.M) {
+	if err := logging.Initialize(nil); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
 
 // Embeds the interface so anything beyond the method under test panics rather
 // than silently passing.
@@ -90,7 +101,7 @@ func TestListRelationsPaging(t *testing.T) {
 			relations: page,
 			count:     3,
 			wantLen:   3,
-			wantNext:  "2026-08-04 12:00:05.5",
+			wantNext:  "2026-08-04T12:00:05.5Z",
 		},
 	}
 
@@ -124,8 +135,8 @@ func TestListRelationsPaging(t *testing.T) {
 	}
 }
 
-// The cursor feeds straight into "created_at < ?::timestamp", so it must carry
-// no offset and keep the fraction the column stores.
+// The cursor feeds straight into "created_at < ?::timestamp", so it has to keep
+// the fraction the column stores. Same format as the created_at the caller saw.
 func TestListRelationsCursorFormat(t *testing.T) {
 	cases := []struct {
 		name string
@@ -135,30 +146,29 @@ func TestListRelationsCursorFormat(t *testing.T) {
 		{
 			name: "microseconds survive",
 			at:   time.Date(2026, 8, 4, 12, 0, 5, 123456000, time.UTC),
-			want: "2026-08-04 12:00:05.123456",
+			want: "2026-08-04T12:00:05.123456Z",
 		},
 		{
 			name: "a whole second carries no fraction",
 			at:   time.Date(2026, 8, 4, 12, 0, 5, 0, time.UTC),
-			want: "2026-08-04 12:00:05",
+			want: "2026-08-04T12:00:05Z",
 		},
 		{
-			name: "a non-UTC location is rendered as wall clock, no offset",
+			name: "a non-UTC location keeps its offset; the cast drops it",
 			at:   time.Date(2026, 8, 4, 12, 0, 5, 0, time.FixedZone("CST", 8*60*60)),
-			want: "2026-08-04 12:00:05",
+			want: "2026-08-04T12:00:05+08:00",
 		},
-		// Values taken from the column itself. Postgres trims trailing zeros
-		// off the fraction, so the layout has to as well or the cursor stops
-		// matching what is stored.
+		// Values taken from the column itself: the fraction must survive
+		// unpadded and untruncated.
 		{
 			name: "full microseconds, as stored",
 			at:   time.Date(2025, 7, 18, 7, 28, 13, 851711000, time.UTC),
-			want: "2025-07-18 07:28:13.851711",
+			want: "2025-07-18T07:28:13.851711Z",
 		},
 		{
 			name: "a trimmed fraction, as stored",
 			at:   time.Date(2025, 10, 23, 13, 53, 55, 19300000, time.UTC),
-			want: "2025-10-23 13:53:55.0193",
+			want: "2025-10-23T13:53:55.0193Z",
 		},
 	}
 
@@ -174,7 +184,7 @@ func TestListRelationsCursorFormat(t *testing.T) {
 			if next != c.want {
 				t.Errorf("next = %q, want %q", next, c.want)
 			}
-			if _, err := time.Parse(models.CursorTimeLayout, next); err != nil {
+			if _, err := time.Parse(time.RFC3339Nano, next); err != nil {
 				t.Errorf("cursor does not round-trip through its own layout: %v", err)
 			}
 		})
@@ -186,14 +196,33 @@ func TestListRelationsForwardsTheCursor(t *testing.T) {
 	r := &fakeResumeStore{relations: relationsAt(time.Now())}
 	s := NewResume(r, fakeAppStore{}, nil)
 
-	if _, _, err := s.ListRelations(context.Background(), "com.yoku.apen", "2026-08-04 12:00:05.5", 20); err != nil {
+	if _, _, err := s.ListRelations(context.Background(), "com.yoku.apen", "2026-08-04T12:00:05.5Z", 20); err != nil {
 		t.Fatalf("ListRelations: %v", err)
 	}
 	if r.gotOpt.Before == nil {
 		t.Fatal("cursor never reached the store")
 	}
-	if *r.gotOpt.Before != "2026-08-04 12:00:05.5" {
-		t.Errorf("cursor = %q, want the one handed in", *r.gotOpt.Before)
+	want := time.Date(2026, 8, 4, 12, 0, 5, 500000000, time.UTC)
+	if !r.gotOpt.Before.Equal(want) {
+		t.Errorf("cursor = %v, want %v", *r.gotOpt.Before, want)
+	}
+}
+
+// The cursor is opaque to the caller, so a mangled or stale one falls back to
+// the newest rows instead of erroring or reaching the database.
+func TestListRelationsIgnoresAnUnparseableCursor(t *testing.T) {
+	for _, cursor := range []string{"2026-08-04 12:00:05.5", "not-a-time", "0"} {
+		t.Run(cursor, func(t *testing.T) {
+			r := &fakeResumeStore{relations: relationsAt(time.Now())}
+			s := NewResume(r, fakeAppStore{}, nil)
+
+			if _, _, err := s.ListRelations(context.Background(), "com.yoku.apen", cursor, 20); err != nil {
+				t.Fatalf("ListRelations: %v", err)
+			}
+			if r.gotOpt.Before != nil {
+				t.Errorf("cursor = %v, want the query left unbounded", *r.gotOpt.Before)
+			}
+		})
 	}
 }
 

--- a/service/resume_test.go
+++ b/service/resume_test.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/A-pen-app/hire-sdk/models"
+	"github.com/A-pen-app/hire-sdk/store"
+)
+
+// Embeds the interface so only the method under test is implemented; anything
+// else ListReceived reaches for panics instead of silently passing.
+type fakeResumeStore struct {
+	store.Resume
+
+	relations []*models.ResumeRelation
+
+	gotAppID   string
+	gotPostIDs []string
+	gotNext    string
+	gotCount   int
+}
+
+func (f *fakeResumeStore) ListReceived(ctx context.Context, appID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, error) {
+	f.gotAppID, f.gotPostIDs, f.gotNext, f.gotCount = appID, postIDs, next, count
+	if count > len(f.relations) {
+		count = len(f.relations)
+	}
+	return f.relations[:count], nil
+}
+
+type fakeAppStore struct {
+	store.App
+}
+
+func (fakeAppStore) GetByBundleID(ctx context.Context, bundleID string) (*models.App, error) {
+	return &models.App{ID: "app-1", BundleID: bundleID}, nil
+}
+
+func relationsAt(times ...time.Time) []*models.ResumeRelation {
+	relations := make([]*models.ResumeRelation, 0, len(times))
+	for _, t := range times {
+		relations = append(relations, &models.ResumeRelation{CreatedAt: t})
+	}
+	return relations
+}
+
+func TestListReceivedPaging(t *testing.T) {
+	// Descending, and the middle two share a second: the cursor has to keep
+	// sub-second precision or the second page skips one of them.
+	base := time.Date(2026, 8, 4, 12, 0, 5, 0, time.UTC)
+	page := relationsAt(
+		base.Add(900*time.Millisecond),
+		base.Add(700*time.Millisecond),
+		base.Add(500*time.Millisecond),
+		base,
+	)
+
+	cases := []struct {
+		name      string
+		relations []*models.ResumeRelation
+		count     int
+		wantLen   int
+		wantNext  string
+	}{
+		{
+			name:      "fewer than a full page ends the list",
+			relations: page[:2],
+			count:     3,
+			wantLen:   2,
+			wantNext:  "",
+		},
+		{
+			name:      "exactly one page ends the list",
+			relations: page[:3],
+			count:     3,
+			wantLen:   3,
+			wantNext:  "",
+		},
+		{
+			name:      "a further row yields the last returned row as the cursor",
+			relations: page,
+			count:     3,
+			wantLen:   3,
+			wantNext:  "2026-08-04 12:00:05.5",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := &fakeResumeStore{relations: c.relations}
+			s := NewResume(r, fakeAppStore{}, nil)
+
+			got, next, err := s.ListReceived(context.Background(), "com.yoku.apen", []string{"post-1"}, "", c.count)
+			if err != nil {
+				t.Fatalf("ListReceived: %v", err)
+			}
+			if len(got) != c.wantLen {
+				t.Errorf("returned %d relations, want %d", len(got), c.wantLen)
+			}
+			if next != c.wantNext {
+				t.Errorf("next = %q, want %q", next, c.wantNext)
+			}
+			// one extra row is what tells the service another page exists
+			if r.gotCount != c.count+1 {
+				t.Errorf("asked the store for %d rows, want %d", r.gotCount, c.count+1)
+			}
+			if r.gotAppID != "app-1" {
+				t.Errorf("app ID = %q, want the one resolved from the bundle ID", r.gotAppID)
+			}
+		})
+	}
+}
+
+// The cursor feeds straight into "created_at < ?::timestamp", so it must carry
+// no offset and keep the fraction the column stores.
+func TestListReceivedCursorFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		at   time.Time
+		want string
+	}{
+		{
+			name: "microseconds survive",
+			at:   time.Date(2026, 8, 4, 12, 0, 5, 123456000, time.UTC),
+			want: "2026-08-04 12:00:05.123456",
+		},
+		{
+			name: "a whole second carries no fraction",
+			at:   time.Date(2026, 8, 4, 12, 0, 5, 0, time.UTC),
+			want: "2026-08-04 12:00:05",
+		},
+		{
+			name: "a non-UTC location is rendered as wall clock, no offset",
+			at:   time.Date(2026, 8, 4, 12, 0, 5, 0, time.FixedZone("CST", 8*60*60)),
+			want: "2026-08-04 12:00:05",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := &fakeResumeStore{relations: relationsAt(c.at, c.at.Add(-time.Second))}
+			s := NewResume(r, fakeAppStore{}, nil)
+
+			_, next, err := s.ListReceived(context.Background(), "com.yoku.apen", []string{"post-1"}, "", 1)
+			if err != nil {
+				t.Fatalf("ListReceived: %v", err)
+			}
+			if next != c.want {
+				t.Errorf("next = %q, want %q", next, c.want)
+			}
+			if _, err := time.Parse(models.CursorTimeLayout, next); err != nil {
+				t.Errorf("cursor does not round-trip through its own layout: %v", err)
+			}
+		})
+	}
+}
+
+func TestListReceivedZeroCountSkipsTheStore(t *testing.T) {
+	r := &fakeResumeStore{relations: relationsAt(time.Now())}
+	s := NewResume(r, fakeAppStore{}, nil)
+
+	got, next, err := s.ListReceived(context.Background(), "com.yoku.apen", []string{"post-1"}, "cursor", 0)
+	if err != nil {
+		t.Fatalf("ListReceived: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("returned %d relations, want none", len(got))
+	}
+	if next != "cursor" {
+		t.Errorf("next = %q, want the cursor handed in", next)
+	}
+	if r.gotCount != 0 {
+		t.Error("store was queried for a zero-sized page")
+	}
+}

--- a/service/resume_test.go
+++ b/service/resume_test.go
@@ -136,6 +136,19 @@ func TestListReceivedCursorFormat(t *testing.T) {
 			at:   time.Date(2026, 8, 4, 12, 0, 5, 0, time.FixedZone("CST", 8*60*60)),
 			want: "2026-08-04 12:00:05",
 		},
+		// Values taken from the column itself. Postgres trims trailing zeros
+		// off the fraction, so the layout has to as well or the cursor stops
+		// matching what is stored.
+		{
+			name: "full microseconds, as stored",
+			at:   time.Date(2025, 7, 18, 7, 28, 13, 851711000, time.UTC),
+			want: "2025-07-18 07:28:13.851711",
+		},
+		{
+			name: "a trimmed fraction, as stored",
+			at:   time.Date(2025, 10, 23, 13, 53, 55, 19300000, time.UTC),
+			want: "2025-10-23 13:53:55.0193",
+		},
 	}
 
 	for _, c := range cases {

--- a/service/resume_test.go
+++ b/service/resume_test.go
@@ -10,22 +10,28 @@ import (
 	"github.com/A-pen-app/hire-sdk/store"
 )
 
-// Embeds the interface so only the method under test is implemented; anything
-// else ListReceived reaches for panics instead of silently passing.
+// Embeds the interface so anything beyond the method under test panics rather
+// than silently passing.
 type fakeResumeStore struct {
 	store.Resume
 
 	relations []*models.ResumeRelation
 
-	gotAppID   string
-	gotPostIDs []string
-	gotNext    string
-	gotCount   int
+	gotAppID string
+	gotOpt   models.ListRelationOption
 }
 
-func (f *fakeResumeStore) ListReceived(ctx context.Context, appID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, error) {
-	f.gotAppID, f.gotPostIDs, f.gotNext, f.gotCount = appID, postIDs, next, count
-	if count > len(f.relations) {
+func (f *fakeResumeStore) ListRelations(ctx context.Context, appID string, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, error) {
+	f.gotAppID = appID
+	f.gotOpt = models.ListRelationOption{}
+	for _, apply := range opts {
+		if err := apply(&f.gotOpt); err != nil {
+			return nil, err
+		}
+	}
+
+	count := f.gotOpt.Count
+	if count == 0 || count > len(f.relations) {
 		count = len(f.relations)
 	}
 	return f.relations[:count], nil
@@ -47,7 +53,7 @@ func relationsAt(times ...time.Time) []*models.ResumeRelation {
 	return relations
 }
 
-func TestListReceivedPaging(t *testing.T) {
+func TestListRelationsPaging(t *testing.T) {
 	// Descending, and the middle two share a second: the cursor has to keep
 	// sub-second precision or the second page skips one of them.
 	base := time.Date(2026, 8, 4, 12, 0, 5, 0, time.UTC)
@@ -93,9 +99,9 @@ func TestListReceivedPaging(t *testing.T) {
 			r := &fakeResumeStore{relations: c.relations}
 			s := NewResume(r, fakeAppStore{}, nil)
 
-			got, next, err := s.ListReceived(context.Background(), "com.yoku.apen", []string{"post-1"}, "", c.count)
+			got, next, err := s.ListRelations(context.Background(), "com.yoku.apen", "", c.count, models.ByPostIDs([]string{"post-1"}))
 			if err != nil {
-				t.Fatalf("ListReceived: %v", err)
+				t.Fatalf("ListRelations: %v", err)
 			}
 			if len(got) != c.wantLen {
 				t.Errorf("returned %d relations, want %d", len(got), c.wantLen)
@@ -104,11 +110,15 @@ func TestListReceivedPaging(t *testing.T) {
 				t.Errorf("next = %q, want %q", next, c.wantNext)
 			}
 			// one extra row is what tells the service another page exists
-			if r.gotCount != c.count+1 {
-				t.Errorf("asked the store for %d rows, want %d", r.gotCount, c.count+1)
+			if r.gotOpt.Count != c.count+1 {
+				t.Errorf("asked the store for %d rows, want %d", r.gotOpt.Count, c.count+1)
 			}
 			if r.gotAppID != "app-1" {
 				t.Errorf("app ID = %q, want the one resolved from the bundle ID", r.gotAppID)
+			}
+			// caller options must survive alongside the pagination one
+			if len(r.gotOpt.PostIDs) != 1 || r.gotOpt.PostIDs[0] != "post-1" {
+				t.Errorf("post IDs = %v, want the caller's option to reach the store", r.gotOpt.PostIDs)
 			}
 		})
 	}
@@ -116,7 +126,7 @@ func TestListReceivedPaging(t *testing.T) {
 
 // The cursor feeds straight into "created_at < ?::timestamp", so it must carry
 // no offset and keep the fraction the column stores.
-func TestListReceivedCursorFormat(t *testing.T) {
+func TestListRelationsCursorFormat(t *testing.T) {
 	cases := []struct {
 		name string
 		at   time.Time
@@ -157,9 +167,9 @@ func TestListReceivedCursorFormat(t *testing.T) {
 			r := &fakeResumeStore{relations: relationsAt(c.at, c.at.Add(-time.Second))}
 			s := NewResume(r, fakeAppStore{}, nil)
 
-			_, next, err := s.ListReceived(context.Background(), "com.yoku.apen", []string{"post-1"}, "", 1)
+			_, next, err := s.ListRelations(context.Background(), "com.yoku.apen", "", 1)
 			if err != nil {
-				t.Fatalf("ListReceived: %v", err)
+				t.Fatalf("ListRelations: %v", err)
 			}
 			if next != c.want {
 				t.Errorf("next = %q, want %q", next, c.want)
@@ -171,18 +181,33 @@ func TestListReceivedCursorFormat(t *testing.T) {
 	}
 }
 
-// A negative count used to reach the store as LIMIT 0 and then index
-// relations[count-1] out of range. Callers inside this repo clamp it, but the
-// SDK is consumed by three others.
-func TestListReceivedNonPositiveCountSkipsTheStore(t *testing.T) {
+// If the cursor never reaches the store, every page returns the newest rows.
+func TestListRelationsForwardsTheCursor(t *testing.T) {
+	r := &fakeResumeStore{relations: relationsAt(time.Now())}
+	s := NewResume(r, fakeAppStore{}, nil)
+
+	if _, _, err := s.ListRelations(context.Background(), "com.yoku.apen", "2026-08-04 12:00:05.5", 20); err != nil {
+		t.Fatalf("ListRelations: %v", err)
+	}
+	if r.gotOpt.Before == nil {
+		t.Fatal("cursor never reached the store")
+	}
+	if *r.gotOpt.Before != "2026-08-04 12:00:05.5" {
+		t.Errorf("cursor = %q, want the one handed in", *r.gotOpt.Before)
+	}
+}
+
+// A negative count used to panic on relations[count-1]. apen clamps it, but
+// three other repos consume this SDK.
+func TestListRelationsNonPositiveCountSkipsTheStore(t *testing.T) {
 	for _, count := range []int{0, -1, -20} {
 		t.Run(strconv.Itoa(count), func(t *testing.T) {
 			r := &fakeResumeStore{relations: relationsAt(time.Now(), time.Now())}
 			s := NewResume(r, fakeAppStore{}, nil)
 
-			got, next, err := s.ListReceived(context.Background(), "com.yoku.apen", []string{"post-1"}, "cursor", count)
+			got, next, err := s.ListRelations(context.Background(), "com.yoku.apen", "cursor", count)
 			if err != nil {
-				t.Fatalf("ListReceived: %v", err)
+				t.Fatalf("ListRelations: %v", err)
 			}
 			if len(got) != 0 {
 				t.Errorf("returned %d relations, want none", len(got))
@@ -190,7 +215,7 @@ func TestListReceivedNonPositiveCountSkipsTheStore(t *testing.T) {
 			if next != "cursor" {
 				t.Errorf("next = %q, want the cursor handed in", next)
 			}
-			if r.gotCount != 0 {
+			if r.gotAppID != "" {
 				t.Error("store was queried for a non-positive page")
 			}
 		})

--- a/service/service.go
+++ b/service/service.go
@@ -11,6 +11,7 @@ type Resume interface {
 	Patch(ctx context.Context, bundleID, userID string, resume *models.ResumeContent) error
 	Get(ctx context.Context, bundleID, userID string) (*models.Resume, error)
 	GetUserAppliedPostIDs(ctx context.Context, bundleID, userID string) ([]string, error)
+	ListReceived(ctx context.Context, bundleID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, string, error)
 	GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error)
 	GetResponseMediansByPost(ctx context.Context, bundleID string, after time.Time) (map[string]float64, error)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -11,7 +11,7 @@ type Resume interface {
 	Patch(ctx context.Context, bundleID, userID string, resume *models.ResumeContent) error
 	Get(ctx context.Context, bundleID, userID string) (*models.Resume, error)
 	GetUserAppliedPostIDs(ctx context.Context, bundleID, userID string) ([]string, error)
-	ListReceived(ctx context.Context, bundleID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, string, error)
+	ListRelations(ctx context.Context, bundleID string, next string, count int, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, string, error)
 	GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error)
 	GetResponseMediansByPost(ctx context.Context, bundleID string, after time.Time) (map[string]float64, error)
 }

--- a/store/resume.go
+++ b/store/resume.go
@@ -471,60 +471,28 @@ func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...m
 		args = append(args, pq.Array(opt.ChatIDs))
 	}
 
+	if len(opt.PostIDs) > 0 {
+		query += ` AND post_id = ANY(?)`
+		args = append(args, pq.Array(opt.PostIDs))
+	}
+
+	// cast to match the column: created_at is timestamp without time zone
+	if opt.Before != nil {
+		query += ` AND created_at < ?::timestamp`
+		args = append(args, *opt.Before)
+	}
+
+	if opt.Count > 0 {
+		query += ` ORDER BY created_at DESC LIMIT ?`
+		args = append(args, opt.Count)
+	}
+
 	query = s.db.Rebind(query)
 
 	var relations []*models.ResumeRelation
 	err := s.db.Select(&relations, query, args...)
 	if err != nil {
 		logging.Errorw(ctx, "failed to list resume relations", "err", err, "appID", appID, "opts", opts)
-		return nil, err
-	}
-	return relations, nil
-}
-
-// ListReceived returns the relations for resumes sent to the given posts,
-// newest first. next is a timestamp cursor. Pair with ListSnapshots for the
-// contents.
-func (s *resumeStore) ListReceived(ctx context.Context, appID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, error) {
-	relations := []*models.ResumeRelation{}
-	if len(postIDs) == 0 {
-		return relations, nil
-	}
-
-	query := `
-	SELECT
-		id,
-		app_id,
-		user_id,
-		snapshot_id,
-		post_id,
-		chat_id,
-		is_read,
-		created_at,
-		updated_at,
-		status
-	FROM public.resume_relation
-	WHERE app_id=?
-	AND post_id=ANY(?)`
-	args := []interface{}{appID, pq.Array(postIDs)}
-
-	// No cursor on the first page. Defaulting it to "now" would mean picking a
-	// zone to render that "now" in, and created_at carries none.
-	if next != "" {
-		query += `
-	AND created_at<?::timestamp`
-		args = append(args, next)
-	}
-
-	query += `
-	ORDER BY created_at DESC
-	LIMIT ?`
-	args = append(args, count)
-
-	query = s.db.Rebind(query)
-
-	if err := s.db.SelectContext(ctx, &relations, query, args...); err != nil {
-		logging.Errorw(ctx, "failed to list received resume relations", "err", err, "appID", appID, "postIDs", postIDs, "count", count)
 		return nil, err
 	}
 	return relations, nil

--- a/store/resume.go
+++ b/store/resume.go
@@ -490,10 +490,6 @@ func (s *resumeStore) ListReceived(ctx context.Context, appID string, postIDs []
 	if len(postIDs) == 0 {
 		return relations, nil
 	}
-	if next == "" {
-		// +2 seconds so a resume created at almost the same moment is not skipped
-		next = time.Now().Add(2 * time.Second).Format(models.CursorTimeLayout)
-	}
 
 	query := `
 	SELECT
@@ -509,14 +505,25 @@ func (s *resumeStore) ListReceived(ctx context.Context, appID string, postIDs []
 		status
 	FROM public.resume_relation
 	WHERE app_id=?
-	AND post_id=ANY(?)
-	AND created_at<?::timestamp
+	AND post_id=ANY(?)`
+	args := []interface{}{appID, pq.Array(postIDs)}
+
+	// No cursor on the first page. Defaulting it to "now" would mean picking a
+	// zone to render that "now" in, and created_at carries none.
+	if next != "" {
+		query += `
+	AND created_at<?::timestamp`
+		args = append(args, next)
+	}
+
+	query += `
 	ORDER BY created_at DESC
-	LIMIT ?
-	`
+	LIMIT ?`
+	args = append(args, count)
+
 	query = s.db.Rebind(query)
 
-	if err := s.db.SelectContext(ctx, &relations, query, appID, pq.Array(postIDs), next, count); err != nil {
+	if err := s.db.SelectContext(ctx, &relations, query, args...); err != nil {
 		logging.Errorw(ctx, "failed to list received resume relations", "err", err, "appID", appID, "postIDs", postIDs, "count", count)
 		return nil, err
 	}

--- a/store/resume.go
+++ b/store/resume.go
@@ -476,7 +476,6 @@ func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...m
 		args = append(args, pq.Array(opt.PostIDs))
 	}
 
-	// cast to match the column: created_at is timestamp without time zone
 	if opt.Before != nil {
 		query += ` AND created_at < ?::timestamp`
 		args = append(args, *opt.Before)

--- a/store/resume.go
+++ b/store/resume.go
@@ -482,6 +482,47 @@ func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...m
 	return relations, nil
 }
 
+// ListReceived returns the relations for resumes sent to the given posts,
+// newest first. next is a timestamp cursor. Pair with ListSnapshots for the
+// contents.
+func (s *resumeStore) ListReceived(ctx context.Context, appID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, error) {
+	relations := []*models.ResumeRelation{}
+	if len(postIDs) == 0 {
+		return relations, nil
+	}
+	if next == "" {
+		// +2 seconds so a resume created at almost the same moment is not skipped
+		next = time.Now().Add(2 * time.Second).Format(models.CursorTimeLayout)
+	}
+
+	query := `
+	SELECT
+		id,
+		app_id,
+		user_id,
+		snapshot_id,
+		post_id,
+		chat_id,
+		is_read,
+		created_at,
+		updated_at,
+		status
+	FROM public.resume_relation
+	WHERE app_id=?
+	AND post_id=ANY(?)
+	AND created_at<?::timestamp
+	ORDER BY created_at DESC
+	LIMIT ?
+	`
+	query = s.db.Rebind(query)
+
+	if err := s.db.SelectContext(ctx, &relations, query, appID, pq.Array(postIDs), next, count); err != nil {
+		logging.Errorw(ctx, "failed to list received resume relations", "err", err, "appID", appID, "postIDs", postIDs, "count", count)
+		return nil, err
+	}
+	return relations, nil
+}
+
 func (s *resumeStore) Read(ctx context.Context, snapshotID string) error {
 	query := `
 	UPDATE public.resume_relation

--- a/store/store.go
+++ b/store/store.go
@@ -18,6 +18,7 @@ type Resume interface {
 	CreateRelation(ctx context.Context, appID, userID string, snapshotID string, chatID string, postID string, status models.ResumeStatus) (*models.ResumeRelation, error)
 	GetRelation(ctx context.Context, opts ...models.GetRelationOptionFunc) (*models.ResumeRelation, error)
 	ListRelations(ctx context.Context, appID string, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, error)
+	ListReceived(ctx context.Context, appID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, error)
 	Read(ctx context.Context, snapshotID string) error
 	UpdateRelationStatus(ctx context.Context, snapshotID string, status models.ResumeStatus) error
 	UpdateRelationListStatus(ctx context.Context, postIDs []string, status models.ResumeStatus) error

--- a/store/store.go
+++ b/store/store.go
@@ -18,7 +18,6 @@ type Resume interface {
 	CreateRelation(ctx context.Context, appID, userID string, snapshotID string, chatID string, postID string, status models.ResumeStatus) (*models.ResumeRelation, error)
 	GetRelation(ctx context.Context, opts ...models.GetRelationOptionFunc) (*models.ResumeRelation, error)
 	ListRelations(ctx context.Context, appID string, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, error)
-	ListReceived(ctx context.Context, appID string, postIDs []string, next string, count int) ([]*models.ResumeRelation, error)
 	Read(ctx context.Context, snapshotID string) error
 	UpdateRelationStatus(ctx context.Context, snapshotID string, status models.ResumeStatus) error
 	UpdateRelationListStatus(ctx context.Context, postIDs []string, status models.ResumeStatus) error


### PR DESCRIPTION
## 為什麼

廠商端要做履歷列表（一次看完收到的所有履歷、依職缺篩選、跳對應聊天室），但目前履歷只能透過徵才聊天室一間一間看，沒有列表入口。

資料層其實已經齊備——`resume_relation` 有 `user_id` / `post_id` / `snapshot_id` / `chat_id` / `is_read` / `created_at` / `status`，缺的只是把查詢曝露出來。`ListRelations` 能過濾的只有 `app_id` / `created_at >=` / `chat_id`，而且無排序、無分頁。

## 改了什麼

`ListRelations` 加兩個 option，**不新增方法、不新增型別**：

```go
// 履歷列表
ListRelations(ctx, appID,
    models.ByPostIDs(postIDs),
    models.Paginate(next, count),
)
```

store 裡就是三個條件式：

```go
if len(opt.PostIDs) > 0 { query += ` AND post_id = ANY(?)` }
if opt.Before != nil    { query += ` AND created_at < ?::timestamp` }
if opt.Count > 0        { query += ` ORDER BY created_at DESC LIMIT ?` }
```

service 層新增同名方法，處理 cursor（取 `count+1` 判斷有無下一頁）：

```go
ListRelations(ctx, bundleID string, next string, count int, opts ...models.ListRelationOptionFunc)
    ([]*models.ResumeRelation, string, error)
```

回既有的 `ResumeRelation`。履歷內容由呼叫端配既有的 `ListSnapshots` 批次取、在記憶體 join——這是既定做法（apen `api/aggregator/aggregator.go:238` 取 relations、`:265` 取 snapshots）。

## 既有呼叫端不受影響

三個既有呼叫端（`service/resume.go:97` 的 `ByAfter`、`service/chat.go:275,545` 的 `ByChatIDs`）加上 apen 的 aggregator，都不傳新 option，產生的 SQL 與改動前逐字相同——**沒有 `ORDER BY`，也沒有 `LIMIT`**。

排序刻意綁在 `Paginate` 裡而非無條件加：`GetResponseMediansByPost` 用 `ByAfter` 可能撈回大量列，平白排序是純粹的浪費，而沒有 `LIMIT` 的查詢本來也不需要排序。

## cursor 沒沿用 GetChats 那套

既有分頁是 unix 秒字串配 `TO_TIMESTAMP(?)`。這支改綁 `time.Time` 配 `?::timestamp`：

1. **型別對不上** — `created_at` 是 `timestamp without time zone`，`TO_TIMESTAMP()` 回傳 `timestamptz`。兩者比較會依 session 的 TimeZone 解讀左邊，行為隨連線設定跑掉
2. **秒會截斷** — `Unix()` 無條件捨去小數。第一頁最後一筆若是 `12:00:05.700`，cursor 變 `12:00:05`，次頁查 `< 12:00:05.000`，中間那 0.7 秒的履歷永遠看不到，而且不會報錯

對外的 cursor 與回應裡的時間欄位**同一種格式**（`time.RFC3339Nano`）——hire 這塊一律 `time.Time`，不該為 cursor 生第二種表示。service 負責解析，壞掉或過期的 cursor 回第一頁而非一路送到 DB 才炸。

**以 docker 起 Postgres 16 實跑驗證過**，參數用 `pq.FormatTimestamp` 實際產出的字串（`"2026-08-04 12:00:05.5Z"`）：`::timestamp` 會丟掉時區標記、保留小數位；同秒不同小數的多筆能正確篩選，UTC 與 `Asia/Taipei` 兩種 session 結果一致。

順帶查證：拿掉 `::timestamp` 讓 Postgres 自行推斷，推的也是 `timestamp without time zone`（不是 `timestamptz`），兩者行為相同——cast 保留為防禦，不是修正。

**第一頁不套 `created_at` 條件**：預設一個「現在」當 cursor 就得挑一個時區去渲染，而 `created_at` 不帶時區。第一頁要的就是最新的 N 筆，不需要 cursor。

`GetChats` / `GetMessages` 有同樣的兩個問題，本 PR 未動——既有行為，要改需另外驗證。

## 測試

`service/resume_test.go`，內嵌 interface 的 fake store，**零新相依**（維持 repo 現有的純 stdlib 風格）。

- 分頁邊界：不滿一頁 / 剛好一頁 / 多一筆；驗證跟 store 要的是 `count+1`，cursor 取的是最後一筆**已回傳**的列，且呼叫端的 option 有跟著傳到
- cursor 有送到 store——它從具名參數變成 option 之後，這條路若斷掉，每頁都回最新那批、翻頁永遠不動，且不會報錯
- cursor 格式：微秒保留、整秒不帶小數；用 `resume_relation` 實際存的值鎖住（`2025-07-18T07:28:13.851711Z`、`2025-10-23T13:53:55.0193Z`）
- 壞掉的 cursor（舊格式、亂碼）回第一頁，不送到 DB
- `count <= 0` 不打 store——先前 `count == 0` 的守衛擋不住負數，`count=-1` 會讓 store 收到 `LIMIT 0` 回空，接著 `relations[count-1]` 索引越界 panic

做過變異測試：把 cursor 改回 `Unix()` 後 4 個斷言紅，包含同一秒跨分頁邊界那個案例。

**未涵蓋**：store 層沒有單元測試（需要真的 Postgres），但上述查詢已用 docker 起的 Postgres 16 手動實跑驗證過。

## 相關

apen-api 的 `GET /resumes` 會消費這支，等本 PR merge 打 tag 後才能開。

設計文件：bridge `docs/initiatives/resume-list/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
