### PR TITLE
feat: ListRelations 分頁改為 offset

### DIFF
--- a/models/resume.go
+++ b/models/resume.go
@@ -254,7 +254,7 @@ type ListRelationOption struct {
 	After   *time.Time
 	ChatIDs []string
 	PostIDs []string
-	Before  *time.Time
+	Offset  int
 	Count   int
 }
 type ListRelationOptionFunc func(*ListRelationOption) error
@@ -280,14 +280,11 @@ func ByPostIDs(postIDs []string) ListRelationOptionFunc {
 	}
 }
 
-// Paginate takes the newest count relations older than before (a zero time
-// starts from the newest). Ordering rides along: a LIMIT without one is
-// arbitrary.
-func Paginate(before time.Time, count int) ListRelationOptionFunc {
+// Paginate takes count relations starting offset rows into the newest-first
+// order. Ordering rides along: a LIMIT without one is arbitrary.
+func Paginate(offset, count int) ListRelationOptionFunc {
 	return func(opt *ListRelationOption) error {
-		if !before.IsZero() {
-			opt.Before = &before
-		}
+		opt.Offset = offset
 		opt.Count = count
 		return nil
 	}

--- a/models/resume.go
+++ b/models/resume.go
@@ -281,9 +281,13 @@ func ByPostIDs(postIDs []string) ListRelationOptionFunc {
 }
 
 // Paginate takes count relations starting offset rows into the newest-first
-// order. Ordering rides along: a LIMIT without one is arbitrary.
+// order. Ordering rides along: a LIMIT without one is arbitrary. A negative
+// offset is clamped here rather than at the query, which Postgres rejects.
 func Paginate(offset, count int) ListRelationOptionFunc {
 	return func(opt *ListRelationOption) error {
+		if offset < 0 {
+			offset = 0
+		}
 		opt.Offset = offset
 		opt.Count = count
 		return nil

--- a/service/resume.go
+++ b/service/resume.go
@@ -83,9 +83,6 @@ func (s *resumeService) ListRelations(ctx context.Context, bundleID string, offs
 	if count <= 0 {
 		return []*models.ResumeRelation{}, nil
 	}
-	if offset < 0 {
-		offset = 0
-	}
 
 	app, err := s.a.GetByBundleID(ctx, bundleID)
 	if err != nil {

--- a/service/resume.go
+++ b/service/resume.go
@@ -77,46 +77,28 @@ func (s *resumeService) GetUserAppliedPostIDs(ctx context.Context, bundleID, use
 	return postIDs, nil
 }
 
-// ListRelations returns one page of relations, newest first, plus the cursor
-// for the next page ("" when there is none). Narrow it with the store's options.
-func (s *resumeService) ListRelations(ctx context.Context, bundleID string, next string, count int, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, string, error) {
-	// <=0, not ==0: a negative count would index relations[count-1]
+// ListRelations returns one page of relations, newest first. Narrow it with
+// the store's options.
+func (s *resumeService) ListRelations(ctx context.Context, bundleID string, offset, count int, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, error) {
 	if count <= 0 {
-		return []*models.ResumeRelation{}, next, nil
+		return []*models.ResumeRelation{}, nil
 	}
-
-	// An unparseable cursor starts from the newest rather than erroring: it is
-	// opaque to the caller, so a bad one means a stale or mangled link.
-	var before time.Time
-	if next != "" {
-		parsed, err := time.Parse(time.RFC3339Nano, next)
-		if err != nil {
-			logging.Infow(ctx, "ignoring unparseable resume cursor", "next", next)
-		} else {
-			before = parsed
-		}
+	if offset < 0 {
+		offset = 0
 	}
 
 	app, err := s.a.GetByBundleID(ctx, bundleID)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get app by bundle ID", "err", err, "bundleID", bundleID)
-		return nil, "", err
+		return nil, err
 	}
 
-	// one extra row tells us whether a further page exists
-	relations, err := s.r.ListRelations(ctx, app.ID, append(opts, models.Paginate(before, count+1))...)
+	relations, err := s.r.ListRelations(ctx, app.ID, append(opts, models.Paginate(offset, count))...)
 	if err != nil {
 		logging.Errorw(ctx, "failed to list resume relations", "err", err, "appID", app.ID)
-		return nil, "", err
+		return nil, err
 	}
-
-	n := len(relations)
-	next = ""
-	if n > count {
-		next = relations[count-1].CreatedAt.Format(time.RFC3339Nano)
-		n = count
-	}
-	return relations[:n], next, nil
+	return relations, nil
 }
 
 func (s *resumeService) GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error) {

--- a/service/resume_test.go
+++ b/service/resume_test.go
@@ -117,16 +117,24 @@ func TestListRelationsPaging(t *testing.T) {
 	}
 }
 
-// A negative offset would reach SQL as a negative OFFSET.
-func TestListRelationsClampsNegativeOffset(t *testing.T) {
+// Postgres rejects a negative OFFSET, and the store is reachable without going
+// through the service, so Paginate clamps it.
+func TestPaginateClampsNegativeOffset(t *testing.T) {
+	opt := models.ListRelationOption{}
+	if err := models.Paginate(-5, 20)(&opt); err != nil {
+		t.Fatalf("Paginate: %v", err)
+	}
+	if opt.Offset != 0 {
+		t.Errorf("offset = %d, want it clamped to 0", opt.Offset)
+	}
+
 	r := &fakeResumeStore{relations: relationsAt(time.Now(), time.Now())}
 	s := NewResume(r, fakeAppStore{}, nil)
-
 	if _, err := s.ListRelations(context.Background(), "com.yoku.apen", -5, 20); err != nil {
 		t.Fatalf("ListRelations: %v", err)
 	}
 	if r.gotOpt.Offset != 0 {
-		t.Errorf("offset = %d, want it clamped to 0", r.gotOpt.Offset)
+		t.Errorf("offset reaching the store = %d, want 0", r.gotOpt.Offset)
 	}
 }
 

--- a/service/resume_test.go
+++ b/service/resume_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/A-pen-app/logging"
 )
 
-// The service logs unconditionally on some paths, and logging.Infow panics on
-// a nil zap logger.
+// The service logs unconditionally on some paths, and logging panics on a nil
+// zap logger.
 func TestMain(m *testing.M) {
 	if err := logging.Initialize(nil); err != nil {
 		panic(err)
@@ -41,11 +41,13 @@ func (f *fakeResumeStore) ListRelations(ctx context.Context, appID string, opts 
 		}
 	}
 
-	count := f.gotOpt.Count
-	if count == 0 || count > len(f.relations) {
-		count = len(f.relations)
+	// stand in for LIMIT/OFFSET
+	from := min(f.gotOpt.Offset, len(f.relations))
+	to := len(f.relations)
+	if f.gotOpt.Count > 0 {
+		to = min(from+f.gotOpt.Count, len(f.relations))
 	}
-	return f.relations[:count], nil
+	return f.relations[from:to], nil
 }
 
 type fakeAppStore struct {
@@ -65,8 +67,6 @@ func relationsAt(times ...time.Time) []*models.ResumeRelation {
 }
 
 func TestListRelationsPaging(t *testing.T) {
-	// Descending, and the middle two share a second: the cursor has to keep
-	// sub-second precision or the second page skips one of them.
 	base := time.Date(2026, 8, 4, 12, 0, 5, 0, time.UTC)
 	page := relationsAt(
 		base.Add(900*time.Millisecond),
@@ -76,53 +76,35 @@ func TestListRelationsPaging(t *testing.T) {
 	)
 
 	cases := []struct {
-		name      string
-		relations []*models.ResumeRelation
-		count     int
-		wantLen   int
-		wantNext  string
+		name    string
+		offset  int
+		count   int
+		wantLen int
+		wantAt  time.Time
 	}{
-		{
-			name:      "fewer than a full page ends the list",
-			relations: page[:2],
-			count:     3,
-			wantLen:   2,
-			wantNext:  "",
-		},
-		{
-			name:      "exactly one page ends the list",
-			relations: page[:3],
-			count:     3,
-			wantLen:   3,
-			wantNext:  "",
-		},
-		{
-			name:      "a further row yields the last returned row as the cursor",
-			relations: page,
-			count:     3,
-			wantLen:   3,
-			wantNext:  "2026-08-04T12:00:05.5Z",
-		},
+		{name: "first page", offset: 0, count: 2, wantLen: 2, wantAt: page[0].CreatedAt},
+		{name: "second page", offset: 2, count: 2, wantLen: 2, wantAt: page[2].CreatedAt},
+		{name: "a partial last page", offset: 3, count: 2, wantLen: 1, wantAt: page[3].CreatedAt},
+		{name: "past the end", offset: 10, count: 2, wantLen: 0},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			r := &fakeResumeStore{relations: c.relations}
+			r := &fakeResumeStore{relations: page}
 			s := NewResume(r, fakeAppStore{}, nil)
 
-			got, next, err := s.ListRelations(context.Background(), "com.yoku.apen", "", c.count, models.ByPostIDs([]string{"post-1"}))
+			got, err := s.ListRelations(context.Background(), "com.yoku.apen", c.offset, c.count, models.ByPostIDs([]string{"post-1"}))
 			if err != nil {
 				t.Fatalf("ListRelations: %v", err)
 			}
 			if len(got) != c.wantLen {
-				t.Errorf("returned %d relations, want %d", len(got), c.wantLen)
+				t.Fatalf("returned %d relations, want %d", len(got), c.wantLen)
 			}
-			if next != c.wantNext {
-				t.Errorf("next = %q, want %q", next, c.wantNext)
+			if c.wantLen > 0 && !got[0].CreatedAt.Equal(c.wantAt) {
+				t.Errorf("page starts at %v, want %v", got[0].CreatedAt, c.wantAt)
 			}
-			// one extra row is what tells the service another page exists
-			if r.gotOpt.Count != c.count+1 {
-				t.Errorf("asked the store for %d rows, want %d", r.gotOpt.Count, c.count+1)
+			if r.gotOpt.Offset != c.offset || r.gotOpt.Count != c.count {
+				t.Errorf("store got offset=%d count=%d, want %d/%d", r.gotOpt.Offset, r.gotOpt.Count, c.offset, c.count)
 			}
 			if r.gotAppID != "app-1" {
 				t.Errorf("app ID = %q, want the one resolved from the bundle ID", r.gotAppID)
@@ -135,114 +117,32 @@ func TestListRelationsPaging(t *testing.T) {
 	}
 }
 
-// The cursor feeds straight into "created_at < ?::timestamp", so it has to keep
-// the fraction the column stores. Same format as the created_at the caller saw.
-func TestListRelationsCursorFormat(t *testing.T) {
-	cases := []struct {
-		name string
-		at   time.Time
-		want string
-	}{
-		{
-			name: "microseconds survive",
-			at:   time.Date(2026, 8, 4, 12, 0, 5, 123456000, time.UTC),
-			want: "2026-08-04T12:00:05.123456Z",
-		},
-		{
-			name: "a whole second carries no fraction",
-			at:   time.Date(2026, 8, 4, 12, 0, 5, 0, time.UTC),
-			want: "2026-08-04T12:00:05Z",
-		},
-		{
-			name: "a non-UTC location keeps its offset; the cast drops it",
-			at:   time.Date(2026, 8, 4, 12, 0, 5, 0, time.FixedZone("CST", 8*60*60)),
-			want: "2026-08-04T12:00:05+08:00",
-		},
-		// Values taken from the column itself: the fraction must survive
-		// unpadded and untruncated.
-		{
-			name: "full microseconds, as stored",
-			at:   time.Date(2025, 7, 18, 7, 28, 13, 851711000, time.UTC),
-			want: "2025-07-18T07:28:13.851711Z",
-		},
-		{
-			name: "a trimmed fraction, as stored",
-			at:   time.Date(2025, 10, 23, 13, 53, 55, 19300000, time.UTC),
-			want: "2025-10-23T13:53:55.0193Z",
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			r := &fakeResumeStore{relations: relationsAt(c.at, c.at.Add(-time.Second))}
-			s := NewResume(r, fakeAppStore{}, nil)
-
-			_, next, err := s.ListRelations(context.Background(), "com.yoku.apen", "", 1)
-			if err != nil {
-				t.Fatalf("ListRelations: %v", err)
-			}
-			if next != c.want {
-				t.Errorf("next = %q, want %q", next, c.want)
-			}
-			if _, err := time.Parse(time.RFC3339Nano, next); err != nil {
-				t.Errorf("cursor does not round-trip through its own layout: %v", err)
-			}
-		})
-	}
-}
-
-// If the cursor never reaches the store, every page returns the newest rows.
-func TestListRelationsForwardsTheCursor(t *testing.T) {
-	r := &fakeResumeStore{relations: relationsAt(time.Now())}
+// A negative offset would reach SQL as a negative OFFSET.
+func TestListRelationsClampsNegativeOffset(t *testing.T) {
+	r := &fakeResumeStore{relations: relationsAt(time.Now(), time.Now())}
 	s := NewResume(r, fakeAppStore{}, nil)
 
-	if _, _, err := s.ListRelations(context.Background(), "com.yoku.apen", "2026-08-04T12:00:05.5Z", 20); err != nil {
+	if _, err := s.ListRelations(context.Background(), "com.yoku.apen", -5, 20); err != nil {
 		t.Fatalf("ListRelations: %v", err)
 	}
-	if r.gotOpt.Before == nil {
-		t.Fatal("cursor never reached the store")
-	}
-	want := time.Date(2026, 8, 4, 12, 0, 5, 500000000, time.UTC)
-	if !r.gotOpt.Before.Equal(want) {
-		t.Errorf("cursor = %v, want %v", *r.gotOpt.Before, want)
+	if r.gotOpt.Offset != 0 {
+		t.Errorf("offset = %d, want it clamped to 0", r.gotOpt.Offset)
 	}
 }
 
-// The cursor is opaque to the caller, so a mangled or stale one falls back to
-// the newest rows instead of erroring or reaching the database.
-func TestListRelationsIgnoresAnUnparseableCursor(t *testing.T) {
-	for _, cursor := range []string{"2026-08-04 12:00:05.5", "not-a-time", "0"} {
-		t.Run(cursor, func(t *testing.T) {
-			r := &fakeResumeStore{relations: relationsAt(time.Now())}
-			s := NewResume(r, fakeAppStore{}, nil)
-
-			if _, _, err := s.ListRelations(context.Background(), "com.yoku.apen", cursor, 20); err != nil {
-				t.Fatalf("ListRelations: %v", err)
-			}
-			if r.gotOpt.Before != nil {
-				t.Errorf("cursor = %v, want the query left unbounded", *r.gotOpt.Before)
-			}
-		})
-	}
-}
-
-// A negative count used to panic on relations[count-1]. apen clamps it, but
-// three other repos consume this SDK.
+// A non-positive count would reach SQL as LIMIT 0 or a negative LIMIT.
 func TestListRelationsNonPositiveCountSkipsTheStore(t *testing.T) {
 	for _, count := range []int{0, -1, -20} {
 		t.Run(strconv.Itoa(count), func(t *testing.T) {
 			r := &fakeResumeStore{relations: relationsAt(time.Now(), time.Now())}
 			s := NewResume(r, fakeAppStore{}, nil)
 
-			got, next, err := s.ListRelations(context.Background(), "com.yoku.apen", "cursor", count)
+			got, err := s.ListRelations(context.Background(), "com.yoku.apen", 0, count)
 			if err != nil {
 				t.Fatalf("ListRelations: %v", err)
 			}
 			if len(got) != 0 {
 				t.Errorf("returned %d relations, want none", len(got))
-			}
-			if next != "cursor" {
-				t.Errorf("next = %q, want the cursor handed in", next)
 			}
 			if r.gotAppID != "" {
 				t.Error("store was queried for a non-positive page")

--- a/service/service.go
+++ b/service/service.go
@@ -11,7 +11,7 @@ type Resume interface {
 	Patch(ctx context.Context, bundleID, userID string, resume *models.ResumeContent) error
 	Get(ctx context.Context, bundleID, userID string) (*models.Resume, error)
 	GetUserAppliedPostIDs(ctx context.Context, bundleID, userID string) ([]string, error)
-	ListRelations(ctx context.Context, bundleID string, next string, count int, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, string, error)
+	ListRelations(ctx context.Context, bundleID string, offset, count int, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, error)
 	GetSnapshot(ctx context.Context, snapshotID string) (*models.ResumeSnapshot, error)
 	GetResponseMediansByPost(ctx context.Context, bundleID string, after time.Time) (map[string]float64, error)
 }

--- a/store/resume.go
+++ b/store/resume.go
@@ -476,14 +476,9 @@ func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...m
 		args = append(args, pq.Array(opt.PostIDs))
 	}
 
-	if opt.Before != nil {
-		query += ` AND created_at < ?::timestamp`
-		args = append(args, *opt.Before)
-	}
-
 	if opt.Count > 0 {
-		query += ` ORDER BY created_at DESC LIMIT ?`
-		args = append(args, opt.Count)
+		query += ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
+		args = append(args, opt.Count, opt.Offset)
 	}
 
 	query = s.db.Rebind(query)


### PR DESCRIPTION
## 為什麼

[#21](https://github.com/A-pen-app/hire-sdk/pull/21) 做的是 cursor 分頁，照的是 `GetChats` 的慣例。但廠商端履歷列表的畫面是**頁碼式**的——可以跳頁、顯示總筆數與每頁筆數。

cursor 給不了這些：只能單向往前走，沒有 offset 就跳不了頁，也算不出總頁數。當初選 cursor 是照著隔壁抄，沒有先確認畫面長怎樣。

## 改了什麼

`Paginate` 的語意換掉：

```go
// 前：比 before 舊的 count 筆
Paginate(before time.Time, count int)
→ AND created_at < ?::timestamp ... ORDER BY created_at DESC LIMIT ?

// 後：跳過 offset 筆之後的 count 筆
Paginate(offset, count int)
→ ORDER BY created_at DESC LIMIT ? OFFSET ?
```

連帶移除所有為 cursor 而存在的東西：`ListRelationOption.Before`、`::timestamp` cast、`RFC3339Nano` 的格式化與解析、`count+1` 的預取。

service 因此簡化——不再需要判斷有沒有下一頁，也不再回傳 `next`：

```go
// 前
ListRelations(ctx, bundleID string, next string, count int, opts ...) ([]*ResumeRelation, string, error)
// 後
ListRelations(ctx, bundleID string, offset, count int, opts ...) ([]*ResumeRelation, error)
```

總筆數由呼叫端自己取得——`CountByPostIDs` 加總即可，不需要額外查詢。

## 既有呼叫端不受影響

`ByAfter`（`service/resume.go`）與 `ByChatIDs`（`service/chat.go` ×2、apen aggregator）都不傳分頁 option，產生的 SQL 與改動前逐字相同：沒有 `ORDER BY`、沒有 `LIMIT`、沒有 `OFFSET`。

## 守衛

| 情況 | 行為 |
|---|---|
| `count <= 0` | 直接回空，不打 DB。原本擋的是索引越界，現在擋 `LIMIT 0` 與負數 `LIMIT` |
| `offset < 0` | 夾到 0，否則會送出負數 `OFFSET` |

## 測試

改成驗 offset 語意：第一頁、第二頁、不滿一頁的最後一頁、超出範圍回空；另外兩條守負數 offset 與非正 count。fake store 以 slice 切片模擬 `LIMIT/OFFSET`，並斷言呼叫端自己的 option（`ByPostIDs`）有跟著傳到 store。

淨 −126 行。

## 簽名變更

`Paginate` 與 `service.ListRelations` 的簽名皆變更。v1.3.20 發出後尚無 consumer 使用（apen 的接入尚未合併），所以現在改的代價最低。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
