### PR TITLE
feat: GetChats 加上依職缺過濾，聊天室加上每人一份的名稱

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ models.ByStatus(models.Todo, false)
 
 // Filter official role chats
 models.IsOfficialRole()
+
+// Filter to one recruit post
+models.ByChatPostID(postID)
+```
+
+**Chat Counts per Post**:
+```go
+// Chats per post for the caller's side. Posts with none are absent from the map.
+counts, err := chatStore.CountByPostIDs(ctx, appID, userID, postIDs)
+```
+
+**Per-participant Chat Name**:
+```go
+// Each side keeps its own name for a chat; the other side never sees it.
+// Pass nil to clear. Read it back from ChatRoom.Name.
+err := chatStore.UpdateName(ctx, chatID, userID, &name)
 ```
 
 **Sending Messages**:

--- a/models/chat.go
+++ b/models/chat.go
@@ -224,6 +224,8 @@ type ChatRoom struct {
 	Status      ChatAnnotation  `json:"status" db:"status"`
 	ControlFlag ChatControlFlag `json:"-" db:"control_flag"`
 	IsPinned    bool            `json:"is_pinned" db:"is_pinned"`
+	// 這一側自己取的名稱，對方看不到。nil 表示沒設過，是否退回 Receiver.Name 由呼叫端決定。
+	Name *string `json:"name" db:"name"`
 
 	//chat
 	AppID                  string                `json:"-" db:"app_id"`
@@ -302,6 +304,7 @@ type GetOption struct {
 	Status         ChatAnnotation
 	UnreadOnly     bool
 	IsOfficialRole bool
+	PostID         *string
 }
 type GetOptionFunc func(*GetOption) error
 
@@ -322,6 +325,14 @@ func ByStatus(status ChatAnnotation, unreadOnly bool) GetOptionFunc {
 func IsOfficialRole() GetOptionFunc {
 	return func(opt *GetOption) error {
 		opt.IsOfficialRole = true
+		return nil
+	}
+}
+
+// 帶 Chat 是為了跟 resume.go 的 ByPostID 區分，同 package 不能重名。
+func ByChatPostID(postID string) GetOptionFunc {
+	return func(opt *GetOption) error {
+		opt.PostID = &postID
 		return nil
 	}
 }

--- a/service/chat.go
+++ b/service/chat.go
@@ -255,7 +255,7 @@ func (s *chatService) GetChats(ctx context.Context, bundleID, userID string, nex
 		}
 	}
 
-	chats, err := s.c.GetChats(ctx, app.ID, userID, next, count+1, opt.Status, opt.UnreadOnly, opt.IsOfficialRole)
+	chats, err := s.c.GetChats(ctx, app.ID, userID, next, count+1, opt.Status, opt.UnreadOnly, opt.IsOfficialRole, opt.PostID)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get chats", "err", err, "appID", app.ID, "userID", userID)
 		return nil, "", err

--- a/store/chat.go
+++ b/store/chat.go
@@ -794,7 +794,7 @@ func (s *chatStore) UpdateName(ctx context.Context, chatID string, userID string
 	WHERE chat_id=? AND sender_id=?
 	`
 	query = s.db.Rebind(query)
-	if _, err := s.db.Exec(query, name, chatID, userID); err != nil {
+	if _, err := s.db.ExecContext(ctx, query, name, chatID, userID); err != nil {
 		logging.Errorw(ctx, "update chat name failed", "err", err, "chatID", chatID, "userID", userID)
 		return err
 	}

--- a/store/chat.go
+++ b/store/chat.go
@@ -209,8 +209,8 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 	return chats, nil
 }
 
-// status 與 control_flag 的條件抄自 GetChats 非 official 的那條路徑。不一致的話，
-// 被封鎖或被管理員隱藏的聊天室會被算進來卻列不出來，選單數字就跟實際翻得到的對不上。
+// 可見性條件跟 GetChats 對齊，只差不帶 cursor（總數本來就要跨頁算）。
+// 改 GetChats 的條件時這裡要跟著改，否則數字會跟實際列得出來的對不上。
 func (s *chatStore) CountByPostIDs(ctx context.Context, appID, userID string, postIDs []string) (map[string]int, error) {
 	counts := map[string]int{}
 	if len(postIDs) == 0 {

--- a/store/chat.go
+++ b/store/chat.go
@@ -209,7 +209,8 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 	return chats, nil
 }
 
-// status 與 control_flag 的條件要跟 GetChats 的預設分支一致，否則數字會跟實際列得出來的對不上。
+// status 與 control_flag 的條件抄自 GetChats 非 official 的那條路徑。不一致的話，
+// 被封鎖或被管理員隱藏的聊天室會被算進來卻列不出來，選單數字就跟實際翻得到的對不上。
 func (s *chatStore) CountByPostIDs(ctx context.Context, appID, userID string, postIDs []string) (map[string]int, error) {
 	counts := map[string]int{}
 	if len(postIDs) == 0 {

--- a/store/chat.go
+++ b/store/chat.go
@@ -42,7 +42,8 @@ func (s *chatStore) Get(ctx context.Context, appID, chatID, userID string) (*mod
 		CT.is_pinned,
 		C.business_card_snapshot_id,
 		C.access_status,
-		CT.hire_contact
+		CT.hire_contact,
+		CT.name
 	FROM public.chat_thread AS CT
 	JOIN public.chat AS C
 	ON CT.chat_id=C.id
@@ -136,7 +137,7 @@ func (s *chatStore) Pin(ctx context.Context, chatID, userID string, isPinned boo
 	return nil
 }
 
-func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, isOfficialRole bool) ([]*models.ChatRoom, error) {
+func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, isOfficialRole bool, postID *string) ([]*models.ChatRoom, error) {
 	chats := []*models.ChatRoom{}
 	if next == "" {
 		// +2 seconds to prevent the last chat is created at almost the same time with getting chats
@@ -159,7 +160,8 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 		CT.is_pinned,
 		C.business_card_snapshot_id,
 		C.access_status,
-		CT.hire_contact
+		CT.hire_contact,
+		CT.name
 	FROM public.chat_thread AS CT
 	JOIN public.chat AS C
 	ON CT.chat_id=C.id
@@ -191,6 +193,10 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 	if unreadOnly {
 		conditions = append(conditions, "CT.unread_count>0")
 	}
+	if postID != nil {
+		conditions = append(conditions, "C.post_id=?")
+		values = append(values, *postID)
+	}
 
 	query = query + strings.Join(conditions, " AND ") + " ORDER BY CT.is_pinned DESC, C.updated_at DESC LIMIT ?"
 	values = append(values, count)
@@ -201,6 +207,42 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 		return nil, err
 	}
 	return chats, nil
+}
+
+// status 與 control_flag 的條件要跟 GetChats 的預設分支一致，否則數字會跟實際列得出來的對不上。
+func (s *chatStore) CountByPostIDs(ctx context.Context, appID, userID string, postIDs []string) (map[string]int, error) {
+	counts := map[string]int{}
+	if len(postIDs) == 0 {
+		return counts, nil
+	}
+
+	query := `
+	SELECT
+		C.post_id,
+		COUNT(*) AS count
+	FROM public.chat_thread AS CT
+	JOIN public.chat AS C
+	ON CT.chat_id=C.id
+	WHERE C.app_id=? AND CT.sender_id=? AND C.post_id=ANY(?)
+		AND CT.status!=? AND CT.control_flag IN (?, ?)
+	GROUP BY C.post_id
+	`
+	query = s.db.Rebind(query)
+
+	rows := []struct {
+		PostID string `db:"post_id"`
+		Count  int    `db:"count"`
+	}{}
+	if err := s.db.SelectContext(ctx, &rows, query, appID, userID, pq.Array(postIDs),
+		models.Deleted, models.Pass, models.NeverGotMessages); err != nil {
+		logging.Errorw(ctx, "count chats by post ids failed", "err", err, "appID", appID, "userID", userID)
+		return nil, err
+	}
+
+	for _, r := range rows {
+		counts[r.PostID] = r.Count
+	}
+	return counts, nil
 }
 
 func (s *chatStore) GetChatID(ctx context.Context, appID, senderID, receiverID string, postID *string, opts ...models.GetChatIDOptionFunc) (string, bool, error) {
@@ -740,6 +782,20 @@ func (s *chatStore) UpdateHireContact(ctx context.Context, chatID string, userID
 	query = s.db.Rebind(query)
 	if _, err := s.db.Exec(query, contact, chatID, userID); err != nil {
 		logging.Errorw(ctx, "update hire contact failed", "err", err, "chatID", chatID, "userID", userID)
+		return err
+	}
+
+	return nil
+}
+
+func (s *chatStore) UpdateName(ctx context.Context, chatID string, userID string, name *string) error {
+	query := `
+	UPDATE public.chat_thread SET name=?
+	WHERE chat_id=? AND sender_id=?
+	`
+	query = s.db.Rebind(query)
+	if _, err := s.db.Exec(query, name, chatID, userID); err != nil {
+		logging.Errorw(ctx, "update chat name failed", "err", err, "chatID", chatID, "userID", userID)
 		return err
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -26,7 +26,8 @@ type Resume interface {
 
 type Chat interface {
 	Get(ctx context.Context, appID, chatID, userID string) (*models.ChatRoom, error)
-	GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, includeNoMessage bool) ([]*models.ChatRoom, error)
+	GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, includeNoMessage bool, postID *string) ([]*models.ChatRoom, error)
+	CountByPostIDs(ctx context.Context, appID, userID string, postIDs []string) (map[string]int, error)
 	GetChatID(ctx context.Context, appID, senderID, receiverID string, postID *string, opts ...models.GetChatIDOptionFunc) (string, bool, error)
 	Read(ctx context.Context, userID, chatID string) error
 	GetMessage(ctx context.Context, messageID string) (*models.Message, error)
@@ -39,6 +40,7 @@ type Chat interface {
 	Annotate(ctx context.Context, chatID, userID string, status models.ChatAnnotation) error
 	Pin(ctx context.Context, chatID, userID string, isPinned bool) error
 	UpdateHireContact(ctx context.Context, chatID string, userID string, contact *models.HireContact) error
+	UpdateName(ctx context.Context, chatID string, userID string, name *string) error
 	UpdateBusinessCardSnapshotID(ctx context.Context, chatID, snapshotID string) error
 	UpdateAccessStatus(ctx context.Context, chatID string, status models.AccessStatus) error
 	GetUserChattingPostIDs(ctx context.Context, appID, userID string) ([]string, error)


### PR DESCRIPTION
## 為什麼

招募方發多個職缺時，收到的應徵聊天室全部混在一份列表裡，沒辦法只看某一則職缺的；聊天室也沒有名稱，顯示的一律是對方的名字，求職者用暱稱或匿名時招募方認不出誰是誰。

呼叫端是 apen-api 的 `GET /hire/chats`（篩選 + 職缺選單）與 `PATCH /hire/chats/{chat_id}`（改名），那邊的接線另外開 PR。

## 改了什麼

**`models.ByChatPostID(postID)`** — `GetChats` 只留下某則職缺的聊天室。查詢本來就鎖在呼叫者的 `chat_thread` 上，`post_id` 只會再縮小範圍，帶別人的職缺 ID 得到的是空結果而不是別人的聊天室，所以呼叫端不需要再做一次 ownership 檢查。

名字帶 `Chat` 是因為 `models.ByPostID` 已經被履歷關聯用掉，同 package 不能重名——這是唯一的理由，不是有什麼語意差別。

**`Chat.CountByPostIDs`** — 每則職缺各有幾間聊天室，給選單用。`status` 與 `control_flag` 的條件刻意抄自 `GetChats` 的預設分支：沒對齊的話選單會顯示「5 個聊天室」但點進去只列得出 3 個，因為沒訊息的空房與被封鎖的房會被算進去卻列不出來。沒有聊天室的職缺不會出現在回傳的 map 裡。

**`ChatRoom.Name` / `Chat.UpdateName`** — 每人一份的聊天室名稱，存 `chat_thread` 而非 `chat`。那張表本來就是每人一列，名稱跟 `is_pinned`、`hire_contact` 同一個模式，寫入照樣鎖 `sender_id`，天生只動到自己那側，對方看不到也改不到。

它與 `Receiver.Name` 是不同層的東西：沒設過時是 `nil`，要不要退回 `Receiver.Name` 由呼叫端決定，SDK 不會幫忙塞。`Get` 與 `GetChats` 兩處 SELECT 都加了，只加一邊會變成列表看得到、點進單一聊天室卻沒有。

## ⚠️ 部署順序

`chat_thread.name` 的 ALTER TABLE 必須先跑，這版才能部署——`Get` 與 `GetChats` 兩處 SELECT 都已經讀這個欄位，欄位不存在的話兩支 API 直接噴錯。

```sql
ALTER TABLE public.chat_thread
    ADD COLUMN IF NOT EXISTS name character varying(30);
```

SQL 檔會放在 apen-api 的 `migrations/`（這個 repo 沒有那個目錄），跟接線的 PR 一起。

## 對其他 repo 的影響

`store.Chat.GetChats` 多收一個 `postID` 參數，`Chat` interface 多兩個 method。已確認 **apen-api / nurse-api / phar-api 都不受影響**：

- 三者都只把 `hireStore.Chat` 當注入型別，拿的是這個 repo 的實作
- `nurse-api` / `phar-api` 呼叫的是 **service 層**的 `GetChats`，簽名沒變（還是 variadic options）
- 沒有任何 repo 自己實作 `Chat` interface（沒有 mock / fake），所以新增 method 不會編譯失敗

## 測試

`go build` / `go vet` / `go test` 皆通過。沒有補新測試——`store` 層本來就沒有測試檔，這三樣的正確性都在 SQL 上，要驗得起 Postgres。

🤖 Generated with [Claude Code](https://claude.com/claude-code)