### PR TITLE
feat: 依求職者姓名搜尋，以及可重用的履歷關聯計數

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ models.ByChatPostID(postID)
 
 // Search the applicant's real_name -- resume snapshot or business card, either
 // counts. Blank input is dropped rather than matching everything.
-models.ByChatApplicantName(keyword)
+models.ByChatRealName(keyword)
 ```
 
 **Chat Counts per Post**:
@@ -151,14 +151,14 @@ counts, err := chatStore.CountByPostIDs(ctx, appID, userID, postIDs)
 **Resume Relation Options and Counts**:
 ```go
 // Search the applicant's real_name on the resume snapshot
-models.ByApplicantName(keyword)
+models.ByRealName(keyword)
 
 // Only relations the recruiter has not opened yet
 models.UnreadOnly()
 
 // Counts what ListRelations would return without Paginate -- same options, same
 // WHERE, so the total always agrees with what can be paged through.
-total, err := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.ByApplicantName(kw))
+total, err := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.ByRealName(kw))
 unread, err := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.UnreadOnly())
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ models.ByChatPostID(postID)
 
 // Search the applicant's real_name -- resume snapshot or business card, either
 // counts. Blank input is dropped rather than matching everything.
-models.ByChatRealName(keyword)
+models.ByRealName(keyword)
 ```
 
 **Chat Counts per Post**:
@@ -150,15 +150,14 @@ counts, err := chatStore.CountByPostIDs(ctx, appID, userID, postIDs)
 
 **Resume Relation Options and Counts**:
 ```go
-// Search the applicant's real_name on the resume snapshot
-models.ByRealName(keyword)
+// Search the real_name on the resume snapshot only
+models.ByResumeRealName(keyword)
 
 // Only relations the recruiter has not opened yet
 models.UnreadOnly()
 
-// Counts what ListRelations would return without Paginate -- same options, same
-// WHERE, so the total always agrees with what can be paged through.
-total, err := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.ByRealName(kw))
+// Same options as ListRelations, so the total always agrees with the list.
+total, err := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.ByResumeRealName(kw))
 unread, err := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.UnreadOnly())
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,12 +136,30 @@ models.IsOfficialRole()
 
 // Filter to one recruit post
 models.ByChatPostID(postID)
+
+// Search the applicant's real_name -- resume snapshot or business card, either
+// counts. Blank input is dropped rather than matching everything.
+models.ByChatApplicantName(keyword)
 ```
 
 **Chat Counts per Post**:
 ```go
 // Chats per post for the caller's side. Posts with none are absent from the map.
 counts, err := chatStore.CountByPostIDs(ctx, appID, userID, postIDs)
+```
+
+**Resume Relation Options and Counts**:
+```go
+// Search the applicant's real_name on the resume snapshot
+models.ByApplicantName(keyword)
+
+// Only relations the recruiter has not opened yet
+models.UnreadOnly()
+
+// Counts what ListRelations would return without Paginate -- same options, same
+// WHERE, so the total always agrees with what can be paged through.
+total, err := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.ByApplicantName(kw))
+unread, err := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.UnreadOnly())
 ```
 
 **Per-participant Chat Name**:

--- a/models/chat.go
+++ b/models/chat.go
@@ -306,7 +306,7 @@ type GetOption struct {
 	UnreadOnly     bool
 	IsOfficialRole bool
 	PostID         *string
-	RealName  *string
+	RealName       *string
 }
 type GetOptionFunc func(*GetOption) error
 
@@ -339,14 +339,9 @@ func ByChatPostID(postID string) GetOptionFunc {
 	}
 }
 
-// ByChatRealName matches the real_name on the applicant's resume snapshot or
-// business card snapshot, case-insensitively, anywhere in the string. Either one
-// counts: the two carry the same person's name, so matching both can only widen
-// the search onto the right chat, never onto a wrong one. Blank or whitespace-only
-// input is dropped rather than matching everything.
-//
-// 名字帶 Chat 是為了跟 resume.go 的 ByRealName 區分，同 package 不能重名。
-func ByChatRealName(name string) GetOptionFunc {
+// 比履歷或名片的 real_name，命中任一即可。空白關鍵字丟掉，不然清空搜尋框會變成
+// 符合全部。
+func ByRealName(name string) GetOptionFunc {
 	return func(opt *GetOption) error {
 		if trimmed := strings.TrimSpace(name); trimmed != "" {
 			opt.RealName = &trimmed

--- a/models/chat.go
+++ b/models/chat.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	feedmodel "github.com/A-pen-app/feed-sdk/model"
@@ -305,6 +306,7 @@ type GetOption struct {
 	UnreadOnly     bool
 	IsOfficialRole bool
 	PostID         *string
+	ApplicantName  *string
 }
 type GetOptionFunc func(*GetOption) error
 
@@ -333,6 +335,22 @@ func IsOfficialRole() GetOptionFunc {
 func ByChatPostID(postID string) GetOptionFunc {
 	return func(opt *GetOption) error {
 		opt.PostID = &postID
+		return nil
+	}
+}
+
+// ByChatApplicantName matches the real_name on the applicant's resume snapshot or
+// business card snapshot, case-insensitively, anywhere in the string. Either one
+// counts: the two carry the same person's name, so matching both can only widen
+// the search onto the right chat, never onto a wrong one. Blank or whitespace-only
+// input is dropped rather than matching everything.
+//
+// 名字帶 Chat 是為了跟 resume.go 的 ByApplicantName 區分，同 package 不能重名。
+func ByChatApplicantName(name string) GetOptionFunc {
+	return func(opt *GetOption) error {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			opt.ApplicantName = &trimmed
+		}
 		return nil
 	}
 }

--- a/models/chat.go
+++ b/models/chat.go
@@ -306,7 +306,7 @@ type GetOption struct {
 	UnreadOnly     bool
 	IsOfficialRole bool
 	PostID         *string
-	ApplicantName  *string
+	RealName  *string
 }
 type GetOptionFunc func(*GetOption) error
 
@@ -339,17 +339,17 @@ func ByChatPostID(postID string) GetOptionFunc {
 	}
 }
 
-// ByChatApplicantName matches the real_name on the applicant's resume snapshot or
+// ByChatRealName matches the real_name on the applicant's resume snapshot or
 // business card snapshot, case-insensitively, anywhere in the string. Either one
 // counts: the two carry the same person's name, so matching both can only widen
 // the search onto the right chat, never onto a wrong one. Blank or whitespace-only
 // input is dropped rather than matching everything.
 //
-// 名字帶 Chat 是為了跟 resume.go 的 ByApplicantName 區分，同 package 不能重名。
-func ByChatApplicantName(name string) GetOptionFunc {
+// 名字帶 Chat 是為了跟 resume.go 的 ByRealName 區分，同 package 不能重名。
+func ByChatRealName(name string) GetOptionFunc {
 	return func(opt *GetOption) error {
 		if trimmed := strings.TrimSpace(name); trimmed != "" {
-			opt.ApplicantName = &trimmed
+			opt.RealName = &trimmed
 		}
 		return nil
 	}

--- a/models/resume.go
+++ b/models/resume.go
@@ -257,7 +257,7 @@ type ListRelationOption struct {
 	PostIDs       []string
 	Offset        int
 	Count         int
-	ApplicantName *string
+	RealName *string
 	UnreadOnly    bool
 }
 type ListRelationOptionFunc func(*ListRelationOption) error
@@ -283,13 +283,13 @@ func ByPostIDs(postIDs []string) ListRelationOptionFunc {
 	}
 }
 
-// ByApplicantName matches the real_name on the applicant's resume snapshot,
+// ByRealName matches the real_name on the applicant's resume snapshot,
 // case-insensitively, anywhere in the string. Blank or whitespace-only input is
 // dropped rather than matching everything.
-func ByApplicantName(name string) ListRelationOptionFunc {
+func ByRealName(name string) ListRelationOptionFunc {
 	return func(opt *ListRelationOption) error {
 		if trimmed := strings.TrimSpace(name); trimmed != "" {
-			opt.ApplicantName = &trimmed
+			opt.RealName = &trimmed
 		}
 		return nil
 	}

--- a/models/resume.go
+++ b/models/resume.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -251,11 +252,13 @@ func ByPostID(postID string) GetRelationOptionFunc {
 }
 
 type ListRelationOption struct {
-	After   *time.Time
-	ChatIDs []string
-	PostIDs []string
-	Offset  int
-	Count   int
+	After         *time.Time
+	ChatIDs       []string
+	PostIDs       []string
+	Offset        int
+	Count         int
+	ApplicantName *string
+	UnreadOnly    bool
 }
 type ListRelationOptionFunc func(*ListRelationOption) error
 
@@ -276,6 +279,25 @@ func ByChatIDs(chatIDs []string) ListRelationOptionFunc {
 func ByPostIDs(postIDs []string) ListRelationOptionFunc {
 	return func(opt *ListRelationOption) error {
 		opt.PostIDs = postIDs
+		return nil
+	}
+}
+
+// ByApplicantName matches the real_name on the applicant's resume snapshot,
+// case-insensitively, anywhere in the string. Blank or whitespace-only input is
+// dropped rather than matching everything.
+func ByApplicantName(name string) ListRelationOptionFunc {
+	return func(opt *ListRelationOption) error {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			opt.ApplicantName = &trimmed
+		}
+		return nil
+	}
+}
+
+func UnreadOnly() ListRelationOptionFunc {
+	return func(opt *ListRelationOption) error {
+		opt.UnreadOnly = true
 		return nil
 	}
 }

--- a/models/resume.go
+++ b/models/resume.go
@@ -252,13 +252,13 @@ func ByPostID(postID string) GetRelationOptionFunc {
 }
 
 type ListRelationOption struct {
-	After         *time.Time
-	ChatIDs       []string
-	PostIDs       []string
-	Offset        int
-	Count         int
-	RealName *string
-	UnreadOnly    bool
+	After      *time.Time
+	ChatIDs    []string
+	PostIDs    []string
+	Offset     int
+	Count      int
+	RealName   *string
+	UnreadOnly bool
 }
 type ListRelationOptionFunc func(*ListRelationOption) error
 
@@ -283,10 +283,8 @@ func ByPostIDs(postIDs []string) ListRelationOptionFunc {
 	}
 }
 
-// ByRealName matches the real_name on the applicant's resume snapshot,
-// case-insensitively, anywhere in the string. Blank or whitespace-only input is
-// dropped rather than matching everything.
-func ByRealName(name string) ListRelationOptionFunc {
+// 只比履歷的 real_name——這份清單的來源是 resume_relation，沒投履歷的人不在裡面。
+func ByResumeRealName(name string) ListRelationOptionFunc {
 	return func(opt *ListRelationOption) error {
 		if trimmed := strings.TrimSpace(name); trimmed != "" {
 			opt.RealName = &trimmed

--- a/service/chat.go
+++ b/service/chat.go
@@ -255,7 +255,7 @@ func (s *chatService) GetChats(ctx context.Context, bundleID, userID string, nex
 		}
 	}
 
-	chats, err := s.c.GetChats(ctx, app.ID, userID, next, count+1, opt.Status, opt.UnreadOnly, opt.IsOfficialRole, opt.PostID, opt.ApplicantName)
+	chats, err := s.c.GetChats(ctx, app.ID, userID, next, count+1, opt.Status, opt.UnreadOnly, opt.IsOfficialRole, opt.PostID, opt.RealName)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get chats", "err", err, "appID", app.ID, "userID", userID)
 		return nil, "", err

--- a/service/chat.go
+++ b/service/chat.go
@@ -255,7 +255,7 @@ func (s *chatService) GetChats(ctx context.Context, bundleID, userID string, nex
 		}
 	}
 
-	chats, err := s.c.GetChats(ctx, app.ID, userID, next, count+1, opt.Status, opt.UnreadOnly, opt.IsOfficialRole, opt.PostID)
+	chats, err := s.c.GetChats(ctx, app.ID, userID, next, count+1, opt.Status, opt.UnreadOnly, opt.IsOfficialRole, opt.PostID, opt.ApplicantName)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get chats", "err", err, "appID", app.ID, "userID", userID)
 		return nil, "", err

--- a/store/chat.go
+++ b/store/chat.go
@@ -137,7 +137,7 @@ func (s *chatStore) Pin(ctx context.Context, chatID, userID string, isPinned boo
 	return nil
 }
 
-func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, isOfficialRole bool, postID *string) ([]*models.ChatRoom, error) {
+func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, isOfficialRole bool, postID *string, applicantName *string) ([]*models.ChatRoom, error) {
 	chats := []*models.ChatRoom{}
 	if next == "" {
 		// +2 seconds to prevent the last chat is created at almost the same time with getting chats
@@ -196,6 +196,20 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 	if postID != nil {
 		conditions = append(conditions, "C.post_id=?")
 		values = append(values, *postID)
+	}
+	if applicantName != nil {
+		// EXISTS rather than joins: a join would have to be threaded into the FROM
+		// clause that every other branch shares.
+		conditions = append(conditions, `(
+			EXISTS (
+				SELECT 1 FROM public.resume_relation RR
+				JOIN public.resume_snapshot RS ON RS.id=RR.snapshot_id
+				WHERE RR.chat_id=C.id AND RS.content->>'real_name' ILIKE ?)
+			OR EXISTS (
+				SELECT 1 FROM public.business_card_snapshot BS
+				WHERE BS.id=C.business_card_snapshot_id AND BS.content->>'real_name' ILIKE ?)
+		)`)
+		values = append(values, "%"+*applicantName+"%", "%"+*applicantName+"%")
 	}
 
 	query = query + strings.Join(conditions, " AND ") + " ORDER BY CT.is_pinned DESC, C.updated_at DESC LIMIT ?"

--- a/store/chat.go
+++ b/store/chat.go
@@ -208,7 +208,8 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 				SELECT 1 FROM public.business_card_snapshot BS
 				WHERE BS.id=C.business_card_snapshot_id AND BS.content->>'real_name' ILIKE ?)
 		)`)
-		values = append(values, "%"+*realName+"%", "%"+*realName+"%")
+		pattern := containsPattern(*realName)
+		values = append(values, pattern, pattern)
 	}
 
 	query = query + strings.Join(conditions, " AND ") + " ORDER BY CT.is_pinned DESC, C.updated_at DESC LIMIT ?"

--- a/store/chat.go
+++ b/store/chat.go
@@ -198,8 +198,7 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 		values = append(values, *postID)
 	}
 	if realName != nil {
-		// EXISTS rather than joins: a join would have to be threaded into the FROM
-		// clause that every other branch shares.
+		// 用 EXISTS 而非 join：join 得改動每個分支共用的 FROM 子句。
 		conditions = append(conditions, `(
 			EXISTS (
 				SELECT 1 FROM public.resume_relation RR

--- a/store/chat.go
+++ b/store/chat.go
@@ -137,7 +137,7 @@ func (s *chatStore) Pin(ctx context.Context, chatID, userID string, isPinned boo
 	return nil
 }
 
-func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, isOfficialRole bool, postID *string, applicantName *string) ([]*models.ChatRoom, error) {
+func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, isOfficialRole bool, postID *string, realName *string) ([]*models.ChatRoom, error) {
 	chats := []*models.ChatRoom{}
 	if next == "" {
 		// +2 seconds to prevent the last chat is created at almost the same time with getting chats
@@ -197,7 +197,7 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 		conditions = append(conditions, "C.post_id=?")
 		values = append(values, *postID)
 	}
-	if applicantName != nil {
+	if realName != nil {
 		// EXISTS rather than joins: a join would have to be threaded into the FROM
 		// clause that every other branch shares.
 		conditions = append(conditions, `(
@@ -209,7 +209,7 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 				SELECT 1 FROM public.business_card_snapshot BS
 				WHERE BS.id=C.business_card_snapshot_id AND BS.content->>'real_name' ILIKE ?)
 		)`)
-		values = append(values, "%"+*applicantName+"%", "%"+*applicantName+"%")
+		values = append(values, "%"+*realName+"%", "%"+*realName+"%")
 	}
 
 	query = query + strings.Join(conditions, " AND ") + " ORDER BY CT.is_pinned DESC, C.updated_at DESC LIMIT ?"

--- a/store/like.go
+++ b/store/like.go
@@ -1,0 +1,12 @@
+package store
+
+import "strings"
+
+// likeEscaper 讓 % 和 _ 以字面比對，否則使用者輸入的那些字元會被當成萬用字元。
+// Postgres 的 LIKE/ILIKE 預設就以反斜線跳脫，不需要 ESCAPE 子句。
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+// containsPattern 把關鍵字包成前後萬用字元的 ILIKE 樣板。
+func containsPattern(keyword string) string {
+	return "%" + likeEscaper.Replace(keyword) + "%"
+}

--- a/store/resume.go
+++ b/store/resume.go
@@ -456,12 +456,12 @@ func relationWhere(appID string, opt models.ListRelationOption) (string, []inter
 	if opt.UnreadOnly {
 		where += ` AND is_read = false`
 	}
-	if opt.ApplicantName != nil {
+	if opt.RealName != nil {
 		where += ` AND EXISTS (
 			SELECT 1 FROM public.resume_snapshot RS
 			WHERE RS.id = resume_relation.snapshot_id
 			  AND RS.content->>'real_name' ILIKE ?)`
-		args = append(args, "%"+*opt.ApplicantName+"%")
+		args = append(args, "%"+*opt.RealName+"%")
 	}
 	return where, args
 }

--- a/store/resume.go
+++ b/store/resume.go
@@ -459,7 +459,7 @@ func relationConditions(appID string, opt models.ListRelationOption) ([]string, 
 			SELECT 1 FROM public.resume_snapshot RS
 			WHERE RS.id = resume_relation.snapshot_id
 			  AND RS.content->>'real_name' ILIKE ?)`)
-		values = append(values, "%"+*opt.RealName+"%")
+		values = append(values, containsPattern(*opt.RealName))
 	}
 	return conditions, values
 }

--- a/store/resume.go
+++ b/store/resume.go
@@ -434,6 +434,59 @@ func (s *resumeStore) GetRelation(ctx context.Context, opts ...models.GetRelatio
 	return &relation, nil
 }
 
+// relationWhere is shared by ListRelations and CountRelations so the two cannot
+// drift: a count built from different conditions than the list disagrees with
+// what the caller can actually page through.
+func relationWhere(appID string, opt models.ListRelationOption) (string, []interface{}) {
+	where := ` WHERE app_id = ?`
+	args := []interface{}{appID}
+
+	if opt.After != nil {
+		where += ` AND created_at >= ?`
+		args = append(args, *opt.After)
+	}
+	if len(opt.ChatIDs) > 0 {
+		where += ` AND chat_id = ANY(?)`
+		args = append(args, pq.Array(opt.ChatIDs))
+	}
+	if len(opt.PostIDs) > 0 {
+		where += ` AND post_id = ANY(?)`
+		args = append(args, pq.Array(opt.PostIDs))
+	}
+	if opt.UnreadOnly {
+		where += ` AND is_read = false`
+	}
+	if opt.ApplicantName != nil {
+		where += ` AND EXISTS (
+			SELECT 1 FROM public.resume_snapshot RS
+			WHERE RS.id = resume_relation.snapshot_id
+			  AND RS.content->>'real_name' ILIKE ?)`
+		args = append(args, "%"+*opt.ApplicantName+"%")
+	}
+	return where, args
+}
+
+// CountRelations counts what ListRelations would return without Paginate.
+func (s *resumeStore) CountRelations(ctx context.Context, appID string, opts ...models.ListRelationOptionFunc) (int, error) {
+	opt := models.ListRelationOption{}
+	for _, f := range opts {
+		if err := f(&opt); err != nil {
+			logging.Errorw(ctx, "failed to apply list relation option", "err", err)
+			return 0, err
+		}
+	}
+
+	where, args := relationWhere(appID, opt)
+	query := s.db.Rebind(`SELECT COUNT(*) FROM public.resume_relation` + where)
+
+	var count int
+	if err := s.db.GetContext(ctx, &count, query, args...); err != nil {
+		logging.Errorw(ctx, "failed to count resume relations", "err", err, "appID", appID)
+		return 0, err
+	}
+	return count, nil
+}
+
 func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, error) {
 	opt := models.ListRelationOption{}
 	for _, f := range opts {
@@ -443,6 +496,7 @@ func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...m
 		}
 	}
 
+	where, args := relationWhere(appID, opt)
 	query := `
 	SELECT
 		id,
@@ -455,26 +509,7 @@ func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...m
 		created_at,
 		updated_at,
 		status
-	FROM public.resume_relation
-	WHERE app_id = ?`
-
-	var args []interface{}
-	args = append(args, appID)
-
-	if opt.After != nil {
-		query += ` AND created_at >= ?`
-		args = append(args, *opt.After)
-	}
-
-	if len(opt.ChatIDs) > 0 {
-		query += ` AND chat_id = ANY(?)`
-		args = append(args, pq.Array(opt.ChatIDs))
-	}
-
-	if len(opt.PostIDs) > 0 {
-		query += ` AND post_id = ANY(?)`
-		args = append(args, pq.Array(opt.PostIDs))
-	}
+	FROM public.resume_relation` + where
 
 	if opt.Count > 0 {
 		query += ` ORDER BY created_at DESC LIMIT ? OFFSET ?`

--- a/store/resume.go
+++ b/store/resume.go
@@ -434,36 +434,36 @@ func (s *resumeStore) GetRelation(ctx context.Context, opts ...models.GetRelatio
 	return &relation, nil
 }
 
-// relationWhere is shared by ListRelations and CountRelations so the two cannot
-// drift: a count built from different conditions than the list disagrees with
-// what the caller can actually page through.
-func relationWhere(appID string, opt models.ListRelationOption) (string, []interface{}) {
-	where := ` WHERE app_id = ?`
-	args := []interface{}{appID}
+// relationConditions is shared by ListRelations and CountRelations so the two
+// cannot drift: a count built from different conditions than the list disagrees
+// with what the caller can actually page through.
+func relationConditions(appID string, opt models.ListRelationOption) ([]string, []interface{}) {
+	conditions := []string{"app_id = ?"}
+	values := []interface{}{appID}
 
 	if opt.After != nil {
-		where += ` AND created_at >= ?`
-		args = append(args, *opt.After)
+		conditions = append(conditions, "created_at >= ?")
+		values = append(values, *opt.After)
 	}
 	if len(opt.ChatIDs) > 0 {
-		where += ` AND chat_id = ANY(?)`
-		args = append(args, pq.Array(opt.ChatIDs))
+		conditions = append(conditions, "chat_id = ANY(?)")
+		values = append(values, pq.Array(opt.ChatIDs))
 	}
 	if len(opt.PostIDs) > 0 {
-		where += ` AND post_id = ANY(?)`
-		args = append(args, pq.Array(opt.PostIDs))
+		conditions = append(conditions, "post_id = ANY(?)")
+		values = append(values, pq.Array(opt.PostIDs))
 	}
 	if opt.UnreadOnly {
-		where += ` AND is_read = false`
+		conditions = append(conditions, "is_read = false")
 	}
 	if opt.RealName != nil {
-		where += ` AND EXISTS (
+		conditions = append(conditions, `EXISTS (
 			SELECT 1 FROM public.resume_snapshot RS
 			WHERE RS.id = resume_relation.snapshot_id
-			  AND RS.content->>'real_name' ILIKE ?)`
-		args = append(args, "%"+*opt.RealName+"%")
+			  AND RS.content->>'real_name' ILIKE ?)`)
+		values = append(values, "%"+*opt.RealName+"%")
 	}
-	return where, args
+	return conditions, values
 }
 
 // CountRelations counts what ListRelations would return without Paginate.
@@ -476,11 +476,14 @@ func (s *resumeStore) CountRelations(ctx context.Context, appID string, opts ...
 		}
 	}
 
-	where, args := relationWhere(appID, opt)
-	query := s.db.Rebind(`SELECT COUNT(*) FROM public.resume_relation` + where)
+	conditions, values := relationConditions(appID, opt)
+	query := s.db.Rebind(`
+	SELECT COUNT(*)
+	FROM public.resume_relation
+	WHERE ` + strings.Join(conditions, " AND "))
 
 	var count int
-	if err := s.db.GetContext(ctx, &count, query, args...); err != nil {
+	if err := s.db.GetContext(ctx, &count, query, values...); err != nil {
 		logging.Errorw(ctx, "failed to count resume relations", "err", err, "appID", appID)
 		return 0, err
 	}
@@ -496,7 +499,7 @@ func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...m
 		}
 	}
 
-	where, args := relationWhere(appID, opt)
+	conditions, values := relationConditions(appID, opt)
 	query := `
 	SELECT
 		id,
@@ -509,17 +512,18 @@ func (s *resumeStore) ListRelations(ctx context.Context, appID string, opts ...m
 		created_at,
 		updated_at,
 		status
-	FROM public.resume_relation` + where
+	FROM public.resume_relation
+	WHERE ` + strings.Join(conditions, " AND ")
 
 	if opt.Count > 0 {
 		query += ` ORDER BY created_at DESC LIMIT ? OFFSET ?`
-		args = append(args, opt.Count, opt.Offset)
+		values = append(values, opt.Count, opt.Offset)
 	}
 
 	query = s.db.Rebind(query)
 
 	var relations []*models.ResumeRelation
-	err := s.db.Select(&relations, query, args...)
+	err := s.db.Select(&relations, query, values...)
 	if err != nil {
 		logging.Errorw(ctx, "failed to list resume relations", "err", err, "appID", appID, "opts", opts)
 		return nil, err

--- a/store/resume.go
+++ b/store/resume.go
@@ -434,9 +434,7 @@ func (s *resumeStore) GetRelation(ctx context.Context, opts ...models.GetRelatio
 	return &relation, nil
 }
 
-// relationConditions is shared by ListRelations and CountRelations so the two
-// cannot drift: a count built from different conditions than the list disagrees
-// with what the caller can actually page through.
+// ListRelations 與 CountRelations 共用，否則總數會跟實際翻得到的筆數對不上。
 func relationConditions(appID string, opt models.ListRelationOption) ([]string, []interface{}) {
 	conditions := []string{"app_id = ?"}
 	values := []interface{}{appID}

--- a/store/store.go
+++ b/store/store.go
@@ -18,6 +18,7 @@ type Resume interface {
 	CreateRelation(ctx context.Context, appID, userID string, snapshotID string, chatID string, postID string, status models.ResumeStatus) (*models.ResumeRelation, error)
 	GetRelation(ctx context.Context, opts ...models.GetRelationOptionFunc) (*models.ResumeRelation, error)
 	ListRelations(ctx context.Context, appID string, opts ...models.ListRelationOptionFunc) ([]*models.ResumeRelation, error)
+	CountRelations(ctx context.Context, appID string, opts ...models.ListRelationOptionFunc) (int, error)
 	Read(ctx context.Context, snapshotID string) error
 	UpdateRelationStatus(ctx context.Context, snapshotID string, status models.ResumeStatus) error
 	UpdateRelationListStatus(ctx context.Context, postIDs []string, status models.ResumeStatus) error
@@ -26,7 +27,7 @@ type Resume interface {
 
 type Chat interface {
 	Get(ctx context.Context, appID, chatID, userID string) (*models.ChatRoom, error)
-	GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, includeNoMessage bool, postID *string) ([]*models.ChatRoom, error)
+	GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, includeNoMessage bool, postID *string, applicantName *string) ([]*models.ChatRoom, error)
 	CountByPostIDs(ctx context.Context, appID, userID string, postIDs []string) (map[string]int, error)
 	GetChatID(ctx context.Context, appID, senderID, receiverID string, postID *string, opts ...models.GetChatIDOptionFunc) (string, bool, error)
 	Read(ctx context.Context, userID, chatID string) error

--- a/store/store.go
+++ b/store/store.go
@@ -27,7 +27,7 @@ type Resume interface {
 
 type Chat interface {
 	Get(ctx context.Context, appID, chatID, userID string) (*models.ChatRoom, error)
-	GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, includeNoMessage bool, postID *string, applicantName *string) ([]*models.ChatRoom, error)
+	GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, includeNoMessage bool, postID *string, realName *string) ([]*models.ChatRoom, error)
 	CountByPostIDs(ctx context.Context, appID, userID string, postIDs []string) (map[string]int, error)
 	GetChatID(ctx context.Context, appID, senderID, receiverID string, postID *string, opts ...models.GetChatIDOptionFunc) (string, bool, error)
 	Read(ctx context.Context, userID, chatID string) error


### PR DESCRIPTION
接在 #23 之後。呼叫端（apen / nurse / phar）的接線另外開 PR。

## 為什麼

廠商後台要能用求職者姓名找人；履歷列表還要一個未讀總數當徽章。

## 姓名搜尋

比對 `real_name`，`ILIKE` 前後萬用字元、大小寫不敏感。**空白或純空白的關鍵字直接丟掉**，不會變成「符合全部」——呼叫端清空搜尋框時最容易送出那個值。使用者輸入的 `%` `_` `\` 會被跳脫，搜「50%」是找字面上的 50%。

兩支 option 的比對來源刻意不同：

| | 用哪支 | 比對什麼 | 為什麼 |
|---|---|---|---|
| 聊天室列表 | `models.ByRealName(kw)` | 履歷或名片，命中任一即可 | 聊天室涵蓋只丟名片的人。同一個人兩份名字本來就相同，比兩個只會更容易找到正確的聊天室，不會找出錯的人 |
| 履歷列表 | `models.ByResumeRealName(kw)` | 只比履歷 | 資料來源是 `resume_relation`，沒投履歷的人根本不在裡面，名片的名字對它沒有意義 |

命名上較窄的那支帶限定詞。不叫 `ByChatRealName` 是因為 `ChatRoom.Name`（#23 加的聊天室備註名）會讓人讀成「用聊天室名稱篩選」。

聊天室那邊用 `EXISTS` 而不是 join——join 得改動每個分支共用的 `FROM` 子句。

## CountRelations

吃跟 `ListRelations` **完全相同的 options**，WHERE 由新的 `relationConditions` 共用產生。

這是刻意的：計數與列表若各自組條件，總數就會跟實際翻得到的筆數對不上，而那種錯誤不會報錯、只會讓頁數靜靜地錯。上一版 `CountByPostIDs` 是靠註解提醒要手動對齊，這次直接讓它不可能漂移。

`UnreadOnly()` 讓同一支方法也算得出未讀徽章，不需要另開一個只做一件事的計數方法：

```go
total,  _ := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.ByResumeRealName(kw))
unread, _ := resumeStore.CountRelations(ctx, appID, models.ByPostIDs(ids), models.UnreadOnly())
```

既有的 `Resume.CountByPostIDs` 沒有動——它餵的是職缺選單，那份選單不該跟著搜尋收斂。

## 新增的公開 API

```go
models.ByRealName(kw)            GetOptionFunc            // 聊天室：履歷或名片
models.ByResumeRealName(kw)      ListRelationOptionFunc   // 履歷：只比履歷
models.UnreadOnly()              ListRelationOptionFunc
store.Resume.CountRelations(ctx, appID, opts...) (int, error)
```

## 對其他 repo 的影響

`store.Chat.GetChats` 多收一個 `realName` 參數，`Resume` interface 多一個 method。三個 consumer 都只把 store 當注入型別、走 service 層的 variadic options，沒有人自己實作這些 interface，所以都不受影響。

不需要 migration。

## 測試

`go build` / `go vet` / `go test` 皆通過。沒有補新測試——`store` 層本來就沒有測試檔，這幾樣的正確性都在 SQL 上，要驗得起 Postgres。

🤖 Generated with [Claude Code](https://claude.com/claude-code)