### PR TITLE
fix: ByPostIDs / ByChatIDs 傳空陣列不該等於不篩

### DIFF
--- a/store/resume.go
+++ b/store/resume.go
@@ -443,11 +443,14 @@ func relationConditions(appID string, opt models.ListRelationOption) ([]string, 
 		conditions = append(conditions, "created_at >= ?")
 		values = append(values, *opt.After)
 	}
-	if len(opt.ChatIDs) > 0 {
+	// nil（沒傳過這個 option）才是不篩。傳了空陣列表示「篩不到任何一筆」，
+	// 產生 ANY('{}')；用 len()>0 判斷的話，兩者都變成不篩，呼叫端一旦傳空
+	// 就會數到整個 app 的資料。
+	if opt.ChatIDs != nil {
 		conditions = append(conditions, "chat_id = ANY(?)")
 		values = append(values, pq.Array(opt.ChatIDs))
 	}
-	if len(opt.PostIDs) > 0 {
+	if opt.PostIDs != nil {
 		conditions = append(conditions, "post_id = ANY(?)")
 		values = append(values, pq.Array(opt.PostIDs))
 	}


### PR DESCRIPTION
[apen-api#535](https://github.com/A-pen-app/apen-api/pull/535) 的 review 點出來的，修在 SDK 而不是呼叫端。

## 問題

`relationConditions` 原本用 `len(opt.PostIDs) > 0` 決定要不要加條件：

```go
if len(opt.PostIDs) > 0 {
    conditions = append(conditions, "post_id = ANY(?)")
}
```

所以呼叫端傳空陣列進來時，整個條件會被省略——意思從「篩不到任何一筆」變成「不篩職缺」，`CountRelations` 就會數到整個 app 的履歷而不是這個使用者的。`ByChatIDs` 同樣寫法同樣問題。

## 修法

改成判斷 `nil`：

| 呼叫端 | `opt.PostIDs` | 產生的條件 | 意思 |
|---|---|---|---|
| 沒傳這個 option | `nil` | 無 | 不篩職缺 |
| `ByPostIDs([]string{})` | 空但非 nil | `post_id = ANY('{}')` | 篩不到任何一筆 |
| `ByPostIDs([...])` | 有值 | `post_id = ANY(...)` | 照篩 |

兩種意圖分得開之後，呼叫端就不需要在外面自己守。

## 目前沒有呼叫端會踩到

這是把地雷拆掉，不是修現行故障：

- apen 的 `getResumes` 在職缺清單為空時就已經提早回傳（`api/hire.go:869`），到計數那裡一定非空
- SDK 內部兩處（`GetChats` 的 `ByChatIDs`、`getResumes` 的 `ByChatIDs`）都包在 `len() > 0` 的判斷裡

## 測試

`go build` / `go vet` / `go test` 皆通過。動到的是 `relationConditions` 一處判斷，`ListRelations` 與 `CountRelations` 共用它，兩邊行為一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)