### PR TITLE
fix: status 型別的 swagger 標成 integer，實際回的是字串

### DIFF
--- a/models/chat.go
+++ b/models/chat.go
@@ -47,6 +47,9 @@ func (t MessageType) String() string {
 	}
 }
 
+// These status types (MessageStatus / ChatAnnotation / AccessStatus, and
+// ResumeStatus in resume.go) store ints but marshal to strings — exposed fields
+// need swaggertype:"string" and enums, or the generated docs say integer.
 type MessageStatus int
 
 const (
@@ -115,7 +118,7 @@ type Message struct {
 	ID        string        `json:"message_id" db:"id" example:"uuid"`
 	ChatID    string        `json:"chat_id" db:"chat_id" example:"uuid"`
 	CreatedAt time.Time     `json:"created_at" db:"created_at" example:"2023-10-01T04:00:00Z"`
-	Status    MessageStatus `json:"status" db:"status"`
+	Status    MessageStatus `json:"status" db:"status" swaggertype:"string" enums:"NORMAL,UNSENT,DELETED,UNAVAILABLE" example:"NORMAL"`
 	IsMine    *bool         `json:"is_mine,omitempty" db:"-"`
 	// 0: 不使用
 	// 1: 文字訊息
@@ -222,7 +225,7 @@ type ChatRoom struct {
 	Receiver    *DisplayUser    `json:"receiver" db:"-"`
 	UnreadCount int64           `json:"unread_count" db:"unread_count"`
 	LastSeenAt  *time.Time      `json:"last_seen_at" db:"last_seen_at" example:"2023-10-01T04:00:00Z"`
-	Status      ChatAnnotation  `json:"status" db:"status"`
+	Status      ChatAnnotation  `json:"status" db:"status" swaggertype:"string" enums:"NONE,TODO,DONE,DELETED" example:"NONE"`
 	ControlFlag ChatControlFlag `json:"-" db:"control_flag"`
 	IsPinned    bool            `json:"is_pinned" db:"is_pinned"`
 	// 這一側自己取的名稱，對方看不到。nil 表示沒設過，是否退回 Receiver.Name 由呼叫端決定。
@@ -238,7 +241,7 @@ type ChatRoom struct {
 	BusinessCardSnapshotID *string               `json:"-" db:"business_card_snapshot_id"`
 	Role                   Role                  `json:"role" db:"-"`
 	HireStatus             *HireStatus           `json:"hire_status" db:"-" default:"INACTIVE" example:"INACTIVE"`
-	AccessStatus           AccessStatus          `json:"access_status" db:"access_status"`
+	AccessStatus           AccessStatus          `json:"access_status" db:"access_status" swaggertype:"string" enums:"LOCKED,UNLOCKED" example:"LOCKED"`
 	ResumeSnapshot         *ChatResumeSnapshot   `json:"resume_snapshot" db:"-"`
 	BusinessCardSnapshot   *BusinessCardSnapshot `json:"business_card_snapshot" db:"-"`
 	HireContact            *HireContact          `json:"hire_contact" db:"hire_contact"`
@@ -260,7 +263,7 @@ type ChatResumeSnapshot struct {
 	ID      string         `json:"id"`
 	Content *ResumeContent `json:"content"`
 	IsRead  bool           `json:"is_read"`
-	Status  ResumeStatus   `json:"status"`
+	Status  ResumeStatus   `json:"status" swaggertype:"string" enums:"LOCKED,UNLOCKED" example:"LOCKED"`
 }
 
 type HireStatus string

--- a/models/resume.go
+++ b/models/resume.go
@@ -183,6 +183,8 @@ type ResumeRelation struct {
 	Status     ResumeStatus `json:"-" db:"status"`
 }
 
+// Stores an int, marshals to a string — exposed fields need the swagger tags
+// (see MessageStatus in chat.go).
 type ResumeStatus int
 
 const (


### PR DESCRIPTION
前端回報的：從 swagger codegen 出來的 TS 型別跟 runtime 對不上，一跑起來就爆。

## 問題

`ResumeStatus` 這類 status 型別都是 `int` 配自訂 `MarshalJSON` 吐字串：

```go
type ResumeStatus int

const (
	ResumeStatusLocked ResumeStatus = iota
	ResumeStatusUnlocked
)

func (u ResumeStatus) MarshalJSON() ([]byte, error) {
	// "LOCKED" / "UNLOCKED"
}
```

swaggo 只看得到底層的 `int`，所以產出的文件是：

```json
"models.ResumeStatus": {
    "type": "integer",
    "enum": [0, 1],
    "x-enum-varnames": ["ResumeStatusLocked", "ResumeStatusUnlocked"]
}
```

但實際回的是 `"LOCKED"` / `"UNLOCKED"`。前端的型別是從 swagger 產的，照文件會產出 `number`，收到字串就對不上。`MessageStatus`、`ChatAnnotation`、`AccessStatus` 全是同一個模式。

## 修法

四個曝露的欄位補上 `swaggertype:"string"` 與對應的 `enums`：

| 欄位 | 型別 | enums |
|---|---|---|
| `Message.status` | `MessageStatus` | `NORMAL,UNSENT,DELETED,UNAVAILABLE` |
| `ChatRoom.status` | `ChatAnnotation` | `NONE,TODO,DONE,DELETED` |
| `ChatRoom.access_status` | `AccessStatus` | `LOCKED,UNLOCKED` |
| `ChatResumeSnapshot.status` | `ResumeStatus` | `LOCKED,UNLOCKED` |

`ResumeRelation.status` 是 `json:"-"`，不會進文件，不用動。

enums 的值是照各型別 `MarshalJSON` 的 switch 逐一對出來的，不是猜的。`MessageStatus` 是 bitflag（`DeletedBySender` 與 `DeletedByReceiver` 都吐 `DELETED`），所以 enums 列的是四個字串而不是五個常數。

**不改型別本身。** 這幾個 status 在 DB 存的是 int（`db:"status"`），改成 string 型別就得連 `Scan`/`Value` 與既有資料一起處理，風險遠大於這個問題本身。這裡只動 struct tag 與註解，序列化行為與 DB 讀寫完全不變。

`MessageStatus` 的型別宣告上加了一段註解說明這個坑，`ResumeStatus` 留一行指回去，之後有人加同型別的欄位才不會又漏掉。

## 驗證

`go build` / `go vet` / `go test` 皆通過。

實際產出的部分，在 apen-api 用 `go mod edit -replace` 指到本地這份 SDK 重跑 `swag init`：

**改之前**

```
models.ResumeStatus     {"type": "integer", "enum": [0, 1]}
models.AccessStatus     {"type": "integer", "enum": [0, 1]}
models.ChatAnnotation   {"type": "integer", "enum": [0, 1, 2, 3]}
models.MessageStatus    {"type": "integer", "enum": [0, 1, 2, 4, 7]}
```

**改之後**（四個 integer 定義直接消失，欄位變成 inline 的字串 enum）

```
Message.status              {"type": "string", "enum": ["NORMAL","UNSENT","DELETED","UNAVAILABLE"]}
ChatRoom.status             {"type": "string", "enum": ["NONE","TODO","DONE","DELETED"]}
ChatRoom.access_status      {"type": "string", "enum": ["LOCKED","UNLOCKED"]}
ChatResumeSnapshot.status   {"type": "string", "enum": ["LOCKED","UNLOCKED"]}
```

驗證用的 replace 已還原，`go.mod` / `go.sum` 沒有留下任何改動。

## 對 import 端的影響

行為零變化，但**文件不會自己更新**——apen / nurse / phar 三個 repo 各自 bump 這版之後要重跑一次 `swag init`，前端才拿得到正確的型別重產 codegen。

apen-api 還有一個 `api.resumeItem.status` 是在它自己的 struct 上，不在這份 SDK 裡，要另外補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
