### PR TITLE
refactor: 列表與計數共用同一組聊天室條件

### DIFF
--- a/models/chat.go
+++ b/models/chat.go
@@ -310,6 +310,12 @@ type GetOption struct {
 	IsOfficialRole bool
 	PostID         *string
 	RealName       *string
+	// AwaitingReply also counts rooms nobody has spoken in yet.
+	AwaitingReply bool
+	// HasPost drops the official room, which every list open recreates.
+	HasPost bool
+	// ExcludeOwnApplications drops the rooms the viewer applied through.
+	ExcludeOwnApplications bool
 }
 type GetOptionFunc func(*GetOption) error
 
@@ -349,6 +355,25 @@ func ByRealName(name string) GetOptionFunc {
 		if trimmed := strings.TrimSpace(name); trimmed != "" {
 			opt.RealName = &trimmed
 		}
+		return nil
+	}
+}
+
+// RecruitingRooms keeps only what the viewer recruits in. Opt in per call — a
+// user can be both a recruiter and a job seeker.
+func RecruitingRooms() GetOptionFunc {
+	return func(opt *GetOption) error {
+		opt.HasPost = true
+		opt.ExcludeOwnApplications = true
+		return nil
+	}
+}
+
+// Unread: the room has unread messages, or nobody has replied in it yet.
+func Unread() GetOptionFunc {
+	return func(opt *GetOption) error {
+		opt.UnreadOnly = true
+		opt.AwaitingReply = true
 		return nil
 	}
 }

--- a/service/chat.go
+++ b/service/chat.go
@@ -236,6 +236,23 @@ func (s *chatService) Get(ctx context.Context, bundleID, chatID, userID string) 
 	return chat, nil
 }
 
+// CountChats counts the rooms matching options; a badge adds models.Unread().
+func (s *chatService) CountChats(ctx context.Context, bundleID, userID string, options ...models.GetOptionFunc) (int, error) {
+	app, err := s.a.GetByBundleID(ctx, bundleID)
+	if err != nil {
+		logging.Errorw(ctx, "failed to get app by bundle ID", "err", err, "bundleID", bundleID)
+		return 0, err
+	}
+
+	opt := models.GetOption{}
+	for _, f := range options {
+		if err := f(&opt); err != nil {
+			return 0, err
+		}
+	}
+	return s.c.CountChats(ctx, app.ID, userID, opt)
+}
+
 func (s *chatService) GetChats(ctx context.Context, bundleID, userID string, next string, count int, options ...models.GetOptionFunc) ([]*models.ChatRoom, string, error) {
 	if count == 0 {
 		return []*models.ChatRoom{}, next, nil
@@ -255,7 +272,7 @@ func (s *chatService) GetChats(ctx context.Context, bundleID, userID string, nex
 		}
 	}
 
-	chats, err := s.c.GetChats(ctx, app.ID, userID, next, count+1, opt.Status, opt.UnreadOnly, opt.IsOfficialRole, opt.PostID, opt.RealName)
+	chats, err := s.c.GetChats(ctx, app.ID, userID, next, count+1, opt)
 	if err != nil {
 		logging.Errorw(ctx, "failed to get chats", "err", err, "appID", app.ID, "userID", userID)
 		return nil, "", err

--- a/service/service.go
+++ b/service/service.go
@@ -20,6 +20,7 @@ type Chat interface {
 	New(ctx context.Context, bundleID, senderID, receiverID string, postID *string, options ...models.NewChatOptionFunc) (string, error)
 	Get(ctx context.Context, bundleID, chatID, userID string) (*models.ChatRoom, error)
 	GetChats(ctx context.Context, bundleID, userID string, next string, count int, options ...models.GetOptionFunc) ([]*models.ChatRoom, string, error)
+	CountChats(ctx context.Context, bundleID, userID string, options ...models.GetOptionFunc) (int, error)
 	GetChatMessages(ctx context.Context, bundleID, userID, chatID string, next string, count int) ([]*models.Message, string, error)
 	FetchNewMessages(ctx context.Context, bundleID, userID, chatID string, lastMessageID string) ([]*models.Message, error)
 	SendMessage(ctx context.Context, bundleID, userID, chatID string, options ...models.SendOptionFunc) (*models.Message, error)

--- a/store/chat.go
+++ b/store/chat.go
@@ -137,7 +137,67 @@ func (s *chatStore) Pin(ctx context.Context, chatID, userID string, isPinned boo
 	return nil
 }
 
-func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, isOfficialRole bool, postID *string, realName *string) ([]*models.ChatRoom, error) {
+// chatConditions is shared by GetChats and CountChats, so a count never
+// disagrees with the list it labels. Paging stays out of it.
+func chatConditions(appID, userID string, opt models.GetOption) ([]string, []interface{}) {
+	conditions := []string{"C.app_id=?", "CT.sender_id=?", "CT.status!=?"}
+	values := []interface{}{appID, userID, models.Deleted}
+
+	if opt.IsOfficialRole {
+		conditions = append(conditions, "((C.post_id IS NULL AND CT.control_flag = ?) OR (C.post_id IS NOT NULL AND CT.control_flag IN (?, ?)))")
+		values = append(values, models.Pass, models.Pass, models.NeverGotMessages)
+	} else {
+		conditions = append(conditions, "CT.control_flag IN (?, ?)")
+		values = append(values, models.Pass, models.NeverGotMessages)
+	}
+	if opt.Status != models.None {
+		conditions = append(conditions, "CT.status=?")
+		values = append(values, opt.Status)
+	}
+	if opt.UnreadOnly {
+		if opt.AwaitingReply {
+			conditions = append(conditions, "(CT.unread_count>0 OR C.last_message_id IS NULL)")
+		} else {
+			conditions = append(conditions, "CT.unread_count>0")
+		}
+	}
+	if opt.HasPost {
+		conditions = append(conditions, "C.post_id IS NOT NULL")
+	}
+	if opt.PostID != nil {
+		conditions = append(conditions, "C.post_id=?")
+		values = append(values, *opt.PostID)
+	}
+	if opt.ExcludeOwnApplications {
+		// Both belong to the job seeker, so either one marks the viewer as one.
+		conditions = append(conditions, `NOT EXISTS (
+			SELECT 1 FROM public.resume_relation RR
+			WHERE RR.chat_id=C.id AND RR.user_id=?)`)
+		values = append(values, userID)
+		conditions = append(conditions, `NOT EXISTS (
+			SELECT 1 FROM public.business_card_snapshot BCS
+			JOIN public.business_card BC ON BC.id=BCS.business_card_id
+			WHERE BCS.id=C.business_card_snapshot_id AND BC.user_id=?)`)
+		values = append(values, userID)
+	}
+	if opt.RealName != nil {
+		// 用 EXISTS 而非 join：join 得改動每個分支共用的 FROM 子句。
+		conditions = append(conditions, `(
+			EXISTS (
+				SELECT 1 FROM public.resume_relation RR
+				JOIN public.resume_snapshot RS ON RS.id=RR.snapshot_id
+				WHERE RR.chat_id=C.id AND RS.content->>'real_name' ILIKE ?)
+			OR EXISTS (
+				SELECT 1 FROM public.business_card_snapshot BS
+				WHERE BS.id=C.business_card_snapshot_id AND BS.content->>'real_name' ILIKE ?)
+		)`)
+		pattern := containsPattern(*opt.RealName)
+		values = append(values, pattern, pattern)
+	}
+	return conditions, values
+}
+
+func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next string, count int, opt models.GetOption) ([]*models.ChatRoom, error) {
 	chats := []*models.ChatRoom{}
 	if next == "" {
 		// +2 seconds to prevent the last chat is created at almost the same time with getting chats
@@ -166,51 +226,10 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 	JOIN public.chat AS C
 	ON CT.chat_id=C.id
 	WHERE `
-	conditions := []string{
-		"C.app_id=?",
-		"CT.sender_id=?",
-		"C.updated_at<TO_TIMESTAMP(?)",
-		"CT.status!=?",
-	}
-	values := []interface{}{
-		appID,
-		userID,
-		next,
-		models.Deleted,
-	}
-
-	if isOfficialRole {
-		conditions = append(conditions, "((C.post_id IS NULL AND CT.control_flag = ?) OR (C.post_id IS NOT NULL AND CT.control_flag IN (?, ?)))")
-		values = append(values, models.Pass, models.Pass, models.NeverGotMessages)
-	} else {
-		conditions = append(conditions, "CT.control_flag IN (?, ?)")
-		values = append(values, models.Pass, models.NeverGotMessages)
-	}
-	if status != models.None {
-		conditions = append(conditions, "CT.status=?")
-		values = append(values, status)
-	}
-	if unreadOnly {
-		conditions = append(conditions, "CT.unread_count>0")
-	}
-	if postID != nil {
-		conditions = append(conditions, "C.post_id=?")
-		values = append(values, *postID)
-	}
-	if realName != nil {
-		// 用 EXISTS 而非 join：join 得改動每個分支共用的 FROM 子句。
-		conditions = append(conditions, `(
-			EXISTS (
-				SELECT 1 FROM public.resume_relation RR
-				JOIN public.resume_snapshot RS ON RS.id=RR.snapshot_id
-				WHERE RR.chat_id=C.id AND RS.content->>'real_name' ILIKE ?)
-			OR EXISTS (
-				SELECT 1 FROM public.business_card_snapshot BS
-				WHERE BS.id=C.business_card_snapshot_id AND BS.content->>'real_name' ILIKE ?)
-		)`)
-		pattern := containsPattern(*realName)
-		values = append(values, pattern, pattern)
-	}
+	conditions, values := chatConditions(appID, userID, opt)
+	// Paging, not visibility.
+	conditions = append(conditions, "C.updated_at<TO_TIMESTAMP(?)")
+	values = append(values, next)
 
 	query = query + strings.Join(conditions, " AND ") + " ORDER BY CT.is_pinned DESC, C.updated_at DESC LIMIT ?"
 	values = append(values, count)
@@ -223,13 +242,15 @@ func (s *chatStore) GetChats(ctx context.Context, appID, userID string, next str
 	return chats, nil
 }
 
-// 可見性條件跟 GetChats 對齊，只差不帶 cursor（總數本來就要跨頁算）。
-// 改 GetChats 的條件時這裡要跟著改，否則數字會跟實際列得出來的對不上。
 func (s *chatStore) CountByPostIDs(ctx context.Context, appID, userID string, postIDs []string) (map[string]int, error) {
 	counts := map[string]int{}
 	if len(postIDs) == 0 {
 		return counts, nil
 	}
+
+	conditions, values := chatConditions(appID, userID, models.GetOption{})
+	conditions = append(conditions, "C.post_id=ANY(?)")
+	values = append(values, pq.Array(postIDs))
 
 	query := `
 	SELECT
@@ -238,8 +259,7 @@ func (s *chatStore) CountByPostIDs(ctx context.Context, appID, userID string, po
 	FROM public.chat_thread AS CT
 	JOIN public.chat AS C
 	ON CT.chat_id=C.id
-	WHERE C.app_id=? AND CT.sender_id=? AND C.post_id=ANY(?)
-		AND CT.status!=? AND CT.control_flag IN (?, ?)
+	WHERE ` + strings.Join(conditions, " AND ") + `
 	GROUP BY C.post_id
 	`
 	query = s.db.Rebind(query)
@@ -248,8 +268,7 @@ func (s *chatStore) CountByPostIDs(ctx context.Context, appID, userID string, po
 		PostID string `db:"post_id"`
 		Count  int    `db:"count"`
 	}{}
-	if err := s.db.SelectContext(ctx, &rows, query, appID, userID, pq.Array(postIDs),
-		models.Deleted, models.Pass, models.NeverGotMessages); err != nil {
+	if err := s.db.SelectContext(ctx, &rows, query, values...); err != nil {
 		logging.Errorw(ctx, "count chats by post ids failed", "err", err, "appID", appID, "userID", userID)
 		return nil, err
 	}
@@ -258,6 +277,37 @@ func (s *chatStore) CountByPostIDs(ctx context.Context, appID, userID string, po
 		counts[r.PostID] = r.Count
 	}
 	return counts, nil
+}
+
+// CountChats counts what GetChats would list under the same options.
+func (s *chatStore) CountChats(ctx context.Context, appID, userID string, opt models.GetOption) (int, error) {
+	conditions, values := chatConditions(appID, userID, opt)
+
+	query := `
+	SELECT COUNT(*)
+	FROM public.chat_thread AS CT
+	JOIN public.chat AS C
+	ON CT.chat_id=C.id
+	WHERE ` + strings.Join(conditions, " AND ")
+	query = s.db.Rebind(query)
+
+	count := 0
+	if err := s.db.GetContext(ctx, &count, query, values...); err != nil {
+		logging.Errorw(ctx, "count chats failed", "err", err, "appID", appID, "userID", userID)
+		return 0, err
+	}
+	return count, nil
+}
+
+// Deprecated: use CountChats with models.RecruitingRooms() and models.Unread().
+func (s *chatStore) CountUnreadChats(ctx context.Context, appID, userID string) (int, error) {
+	opt := models.GetOption{}
+	for _, f := range []models.GetOptionFunc{models.RecruitingRooms(), models.Unread()} {
+		if err := f(&opt); err != nil {
+			return 0, err
+		}
+	}
+	return s.CountChats(ctx, appID, userID, opt)
 }
 
 func (s *chatStore) GetChatID(ctx context.Context, appID, senderID, receiverID string, postID *string, opts ...models.GetChatIDOptionFunc) (string, bool, error) {

--- a/store/chat_test.go
+++ b/store/chat_test.go
@@ -1,0 +1,128 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/A-pen-app/hire-sdk/models"
+	"github.com/A-pen-app/logging"
+	"github.com/jmoiron/sqlx"
+)
+
+// The store logs on error paths, and logging panics on a nil zap logger.
+func TestMain(m *testing.M) {
+	if err := logging.Initialize(nil); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestCountChatsUnreadRooms(t *testing.T) {
+	conn := &recordingConnector{rows: [][]driver.Value{{int64(3)}}}
+	db := sqlx.NewDb(sql.OpenDB(conn), "postgres")
+	defer db.Close()
+
+	opt := models.GetOption{}
+	for _, f := range []models.GetOptionFunc{models.RecruitingRooms(), models.Unread()} {
+		if err := f(&opt); err != nil {
+			t.Fatalf("option failed: %v", err)
+		}
+	}
+	count, err := NewChat(db).CountChats(context.Background(), "app-1", "user-1", opt)
+	if err != nil {
+		t.Fatalf("CountChats failed: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+
+	// 未讀的兩種來源都要在；官方房（沒有 post_id）與他自己去應徵的房都不能算進去
+	for _, want := range []string{
+		"CT.unread_count>0 OR C.last_message_id IS NULL",
+		"C.post_id IS NOT NULL",
+		"public.resume_relation RR",
+		"public.business_card_snapshot BCS",
+	} {
+		if !strings.Contains(conn.query, want) {
+			t.Errorf("query missing %q:\n%s", want, conn.query)
+		}
+	}
+
+	// Rebind 之後靠位置對應，順序錯了就會用別人的值去篩
+	wantArgs := []driver.Value{
+		"app-1", "user-1",
+		int64(models.Deleted), int64(models.Pass), int64(models.NeverGotMessages),
+		// 排除自己是求職方的房：履歷一次、名片一次
+		"user-1", "user-1",
+	}
+	if len(conn.args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", conn.args, wantArgs)
+	}
+	for i := range wantArgs {
+		if conn.args[i] != wantArgs[i] {
+			t.Errorf("args[%d] = %v, want %v", i, conn.args[i], wantArgs[i])
+		}
+	}
+}
+
+// 這層沒有 DB 測試基礎建設，與其為了一支查詢引進 mock 套件，不如記下真正送出去的
+// SQL 與參數。
+type recordingConnector struct {
+	rows [][]driver.Value
+
+	query string
+	args  []driver.Value
+}
+
+func (c *recordingConnector) Connect(context.Context) (driver.Conn, error) {
+	return &recordingConn{c: c}, nil
+}
+
+func (c *recordingConnector) Driver() driver.Driver { return nil }
+
+type recordingConn struct {
+	c *recordingConnector
+}
+
+func (c *recordingConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.c.query = query
+	c.c.args = nil
+	for _, arg := range args {
+		c.c.args = append(c.c.args, arg.Value)
+	}
+	return &recordingRows{values: c.c.rows}, nil
+}
+
+func (c *recordingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *recordingConn) Close() error { return nil }
+
+func (c *recordingConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+type recordingRows struct {
+	values [][]driver.Value
+	next   int
+}
+
+func (r *recordingRows) Columns() []string { return []string{"count"} }
+
+func (r *recordingRows) Close() error { return nil }
+
+func (r *recordingRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.next])
+	r.next++
+	return nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -27,8 +27,11 @@ type Resume interface {
 
 type Chat interface {
 	Get(ctx context.Context, appID, chatID, userID string) (*models.ChatRoom, error)
-	GetChats(ctx context.Context, appID, userID string, next string, count int, status models.ChatAnnotation, unreadOnly bool, includeNoMessage bool, postID *string, realName *string) ([]*models.ChatRoom, error)
+	GetChats(ctx context.Context, appID, userID string, next string, count int, opt models.GetOption) ([]*models.ChatRoom, error)
 	CountByPostIDs(ctx context.Context, appID, userID string, postIDs []string) (map[string]int, error)
+	CountChats(ctx context.Context, appID, userID string, opt models.GetOption) (int, error)
+	// Deprecated: use CountChats with models.RecruitingRooms() and models.Unread().
+	CountUnreadChats(ctx context.Context, appID, userID string) (int, error)
 	GetChatID(ctx context.Context, appID, senderID, receiverID string, postID *string, opts ...models.GetChatIDOptionFunc) (string, bool, error)
 	Read(ctx context.Context, userID, chatID string) error
 	GetMessage(ctx context.Context, messageID string) (*models.Message, error)


### PR DESCRIPTION
三平台的聊天室列表要掛未讀 badge。原本補的 `CountUnreadChats` 是把 `GetChats` 的條件抄過去再改一改——兩邊各自維護遲早會漂開，而**一個跟它標示的列表對不起來的數字就是 bug**。

## 共用條件

`chatConditions(appID, userID, opt)` 一份，`GetChats`、`CountChats`、`CountByPostIDs` 都走它。原本兩個 count 上頭各有一段「改 GetChats 記得跟著改」的註解，那種靠人記得的約定現在由程式碼保證。

`store.GetChats` 的五個位置參數（status／unreadOnly／isOfficialRole／postID／realName）收成一個 `models.GetOption`，所以之後加任何選項都自動通到列表與計數兩邊，不必再改一次管線。

## 兩個新選項

| 選項 | 條件 |
|---|---|
| `RecruitingRooms()` | 排掉官方客服房（`post_id IS NULL`）與**自己去應徵的房** |
| `Unread()` | `unread_count > 0` 或還沒有人回話（`last_message_id IS NULL`） |

「自己去應徵的房」用 hiring 自己的資料就分得出來——**履歷與名片都是求職方的**：

```sql
NOT EXISTS (SELECT 1 FROM resume_relation RR
            WHERE RR.chat_id = C.id AND RR.user_id = ?)          -- 投履歷
NOT EXISTS (SELECT 1 FROM business_card_snapshot BCS
            JOIN business_card BC ON BC.id = BCS.business_card_id
            WHERE BCS.id = C.business_card_snapshot_id
              AND BC.user_id = ?)                                -- 名片開場
```

兩個都是**選配**：一個人可以同時是徵才方與求職方，所以要不要過濾由呼叫端決定，不是預設行為。badge 的用法是「列表那組選項 + `Unread()`」，數出來的一定是列表看得到的房間。

## 相容

- `store.CountUnreadChats` **留著**，標 `Deprecated`，內容改為 `CountChats(RecruitingRooms + Unread)`。nurse-api 現有的呼叫一行都不用改，而且直接得到新行為（多排掉自己應徵的房）
- `service.GetChats` 簽名沒動
- `models.GetOption` 只加欄位，零值＝原本行為
- `store.GetChats` 簽名改了，但三平台都是打 service，測試 double 也是內嵌介面，沒有實作它

新增 `service.CountChats`——先前只有 store 有計數，平台沒有東西可以呼叫。

## 之後

三平台的 `/hire/chats` 回應加 `unread_count`；廠商那側（醫起行後台前端直打三平台）帶 `?role=recruiter` 才過濾，App 不帶、行為照舊。