### PR TITLE
feat(chat): filter the chat list by the room's own name too

### DIFF
--- a/models/chat.go
+++ b/models/chat.go
@@ -309,7 +309,7 @@ type GetOption struct {
 	UnreadOnly     bool
 	IsOfficialRole bool
 	PostID         *string
-	RealName       *string
+	Keyword        *string
 	// AwaitingReply also counts rooms nobody has spoken in yet.
 	AwaitingReply bool
 	// HasPost drops the official room, which every list open recreates.
@@ -348,12 +348,12 @@ func ByChatPostID(postID string) GetOptionFunc {
 	}
 }
 
-// 比履歷或名片的 real_name，命中任一即可。空白關鍵字丟掉，不然清空搜尋框會變成
-// 符合全部。
-func ByRealName(name string) GetOptionFunc {
+// 比履歷姓名、名片姓名與自訂名稱，命中任一即可。空白丟掉，不然清空搜尋框會
+// 變成符合全部。
+func ByKeyword(keyword string) GetOptionFunc {
 	return func(opt *GetOption) error {
-		if trimmed := strings.TrimSpace(name); trimmed != "" {
-			opt.RealName = &trimmed
+		if trimmed := strings.TrimSpace(keyword); trimmed != "" {
+			opt.Keyword = &trimmed
 		}
 		return nil
 	}

--- a/store/chat.go
+++ b/store/chat.go
@@ -180,8 +180,9 @@ func chatConditions(appID, userID string, opt models.GetOption) ([]string, []int
 			WHERE BCS.id=C.business_card_snapshot_id AND BC.user_id=?)`)
 		values = append(values, userID)
 	}
-	if opt.RealName != nil {
-		// 用 EXISTS 而非 join：join 得改動每個分支共用的 FROM 子句。
+	if opt.Keyword != nil {
+		// 履歷、名片、自訂名稱三個都比；CT 已被 sender_id 圈住，所以比到的是自己
+		// 取的名字。用 EXISTS 而非 join：join 得改動每個分支共用的 FROM 子句。
 		conditions = append(conditions, `(
 			EXISTS (
 				SELECT 1 FROM public.resume_relation RR
@@ -190,9 +191,10 @@ func chatConditions(appID, userID string, opt models.GetOption) ([]string, []int
 			OR EXISTS (
 				SELECT 1 FROM public.business_card_snapshot BS
 				WHERE BS.id=C.business_card_snapshot_id AND BS.content->>'real_name' ILIKE ?)
+			OR CT.name ILIKE ?
 		)`)
-		pattern := containsPattern(*opt.RealName)
-		values = append(values, pattern, pattern)
+		pattern := containsPattern(*opt.Keyword)
+		values = append(values, pattern, pattern, pattern)
 	}
 	return conditions, values
 }


### PR DESCRIPTION
## 為什麼

聊天室列表的搜尋只比**履歷姓名**與**名片姓名**。但這批同時上線的還有「每一側可以自己為聊天室取名」——房被改過名之後，使用者記得的就是那個名字，搜下去卻找不到。

## 改了什麼

SQL 多一條 OR：

```sql
  EXISTS (…resume_snapshot… RS.content->>'real_name' ILIKE ?)
  OR EXISTS (…business_card_snapshot… BS.content->>'real_name' ILIKE ?)
+ OR CT.name ILIKE ?
```

`chatConditions` 的基礎條件本來就有 `CT.sender_id = ?`，所以 **`CT.name` 比到的是「自己取的名字」，不是對方取的**——三個呼叫點（`GetChats`／`CountChats`／`CountByPostIDs`）的 `FROM` 都是 `public.chat_thread AS CT`，不必改任何 FROM 子句。

## 選項連帶改名

`ByRealName` → **`ByKeyword`**，`GetOption.RealName` → `Keyword`。現在比的是三個名字，叫 `real_name` 已經不準。

**沒有留相容別名**——呼叫端只有三個平台，這批一起升。

**履歷列表那支不動**（`ByResumeRealName`／`ListRelationOption.RealName`）：履歷沒有自訂名稱，那裡叫 real_name 是準的。

## 平台端要跟著改

合併並發 tag 之後，apen／nurse／phar 各三行：

```go
RealName string `form:"real_name"`      →  Keyword string `form:"keyword"`
hireModels.ByRealName(param.RealName)   →  hireModels.ByKeyword(param.Keyword)
@Param real_name …                      →  @Param keyword …
```

HTTP 參數也直接改名不留相容（已確認可以）。

## 驗證

`go build ./...`、`go vet ./...`、`go test ./...` 全過。